### PR TITLE
Instructions UI overhaul, contact form, and ci-matrix cache fix

### DIFF
--- a/content/contact.mdx
+++ b/content/contact.mdx
@@ -1,47 +1,7 @@
+import { ContactForm } from "@/components/ContactForm";
+
 # Contact
 
-<div className="not-prose mt-6 flex flex-wrap items-center gap-3">
-  <a
-    href="mailto:zach.attas@gmail.com"
-    aria-label="Email"
-    className="inline-flex h-11 w-11 items-center justify-center rounded-xl border border-zinc-200/70 bg-white text-xl shadow-sm transition hover:border-zinc-300/80 hover:shadow-md dark:border-zinc-800/70 dark:bg-zinc-950 dark:hover:border-zinc-700/80"
-  >
-    <img src="/icons/mail.svg" alt="" className="h-5 w-5" />
-  </a>
-  <a
-    href="https://github.com/snackattas"
-    target="_blank"
-    rel="noopener noreferrer"
-    aria-label="GitHub"
-    className="inline-flex h-11 w-11 items-center justify-center rounded-xl border border-zinc-200/70 bg-white text-xl shadow-sm transition hover:border-zinc-300/80 hover:shadow-md dark:border-zinc-800/70 dark:bg-zinc-950 dark:hover:border-zinc-700/80"
-  >
-    <img src="/icons/github.svg" alt="" className="h-5 w-5" />
-  </a>
-  <a
-    href="https://www.linkedin.com/in/zachary-attas-79b9a153"
-    target="_blank"
-    rel="noopener noreferrer"
-    aria-label="LinkedIn"
-    className="inline-flex h-11 w-11 items-center justify-center rounded-xl border border-zinc-200/70 bg-white text-xl shadow-sm transition hover:border-zinc-300/80 hover:shadow-md dark:border-zinc-800/70 dark:bg-zinc-950 dark:hover:border-zinc-700/80"
-  >
-    <img src="/icons/linkedin.svg" alt="" className="h-5 w-5" />
-  </a>
-  <a
-    href="https://www.google.com/maps/place/Chicago,+IL"
-    target="_blank"
-    rel="noopener noreferrer"
-    aria-label="Chicago on Google Maps"
-    className="inline-flex h-11 w-11 items-center justify-center rounded-xl border border-zinc-200/70 bg-white text-xl shadow-sm transition hover:border-zinc-300/80 hover:shadow-md dark:border-zinc-800/70 dark:bg-zinc-950 dark:hover:border-zinc-700/80"
-  >
-    <img src="/icons/map-pin.svg" alt="" className="h-5 w-5" />
-  </a>
-  <a
-    href="https://medium.com/@zach.attas"
-    target="_blank"
-    rel="noopener noreferrer"
-    aria-label="Medium"
-    className="inline-flex h-11 w-11 items-center justify-center rounded-xl border border-zinc-200/70 bg-white text-xl shadow-sm transition hover:border-zinc-300/80 hover:shadow-md dark:border-zinc-800/70 dark:bg-zinc-950 dark:hover:border-zinc-700/80"
-  >
-    <img src="/icons/medium.svg" alt="" className="h-5 w-5" />
-  </a>
-</div>
+Got a question, ran into a script issue, or just want to say hi?
+
+<ContactForm />

--- a/src/app/api/ci-matrix/route.ts
+++ b/src/app/api/ci-matrix/route.ts
@@ -61,7 +61,7 @@ export async function GET() {
     { runUrl: latestRun.html_url, jobUrls },
     {
       headers: {
-        "Cache-Control": "public, max-age=3600, stale-while-revalidate=86400",
+        "Cache-Control": "public, max-age=300, stale-while-revalidate=600",
       },
     }
   );

--- a/src/components/AutomationFun/AutomationFunSection.tsx
+++ b/src/components/AutomationFun/AutomationFunSection.tsx
@@ -18,10 +18,9 @@ const fallbackScripts: Record<string, Record<string, string>> = {};
 // Instructions per tool/language
 const instructions: Record<string, Record<string, string>> = {
   playwright: {
-    python: `1. Install Playwright and create file (if the browser crashes on run, re-run this step to upgrade):
+    python: `1. Install Playwright (if the browser crashes on run, re-run this step to upgrade):
    pip install --upgrade playwright
    playwright install
-   touch playwright_fun.py
 
 2. Save the script below to playwright_fun.py
 
@@ -62,19 +61,17 @@ const instructions: Record<string, Record<string, string>> = {
 
 4. Compile and run:
    mvn compile exec:java -Dexec.mainClass=PlaywrightFun`,
-    javascript: `1. Install Playwright and create file:
+    javascript: `1. Install Playwright:
    npm install playwright
    npx playwright install
-   touch playwright_fun.js
 
 2. Save the script below to playwright_fun.js
 
 3. Run the script:
    node playwright_fun.js`,
-    ruby: `1. Install Playwright and create file:
+    ruby: `1. Install Playwright:
    gem install playwright-ruby-client
    playwright install
-   touch playwright_fun.rb
 
 2. Save the script below to playwright_fun.rb
 
@@ -82,9 +79,8 @@ const instructions: Record<string, Record<string, string>> = {
    ruby playwright_fun.rb`,
   },
   selenium: {
-    python: `1. Install Selenium and create file:
+    python: `1. Install Selenium:
    pip install --upgrade selenium
-   touch selenium_fun.py
 
 2. Save the script below to selenium_fun.py
 
@@ -122,17 +118,15 @@ const instructions: Record<string, Record<string, string>> = {
 
 3. Compile and run (requires Chrome — if you see errors, update Chrome to the latest version):
    mvn compile exec:java -Dexec.mainClass=SeleniumFun`,
-    javascript: `1. Install Selenium WebDriver and create file:
+    javascript: `1. Install Selenium WebDriver:
    npm install selenium-webdriver
-   touch selenium_fun.js
 
 2. Save the script below to selenium_fun.js
 
 3. Run the script (requires Chrome — if you see errors, update Chrome to the latest version):
    node selenium_fun.js`,
-    ruby: `1. Install Selenium WebDriver and create file (requires Ruby >= 3.0):
+    ruby: `1. Install Selenium WebDriver (requires Ruby >= 3.0):
    gem install selenium-webdriver -v 4.33.0
-   touch selenium_fun.rb
 
 2. Save the script below to selenium_fun.rb
 
@@ -141,11 +135,10 @@ const instructions: Record<string, Record<string, string>> = {
 Note: the script pins selenium-webdriver to 4.33.0 via a gem() directive — newer versions have a Ruby 3.3 incompatibility.`,
   },
   cypress: {
-    javascript: `1. Install Cypress and create files:
+    javascript: `1. Install Cypress:
    npm install cypress
-   touch cypress.config.js cypress_fun.cy.js
 
-2. Save cypress.config.js content:
+2. Create cypress.config.js:
    cat > cypress.config.js << 'EOF'
    const { defineConfig } = require('cypress');
    module.exports = defineConfig({
@@ -157,13 +150,14 @@ Note: the script pins selenium-webdriver to 4.33.0 via a gem() directive — new
    });
    EOF
 
-3. Save the script below to cypress_fun.cy.js and run:
+3. Save the script below to cypress_fun.cy.js
+
+4. Run the script:
    npx cypress run --headed`,
   },
   vibium: {
-    python: `1. Install Vibium and create file:
+    python: `1. Install Vibium:
    pip install --upgrade vibium
-   touch vibium_fun.py
 
 2. Save the script below to vibium_fun.py
 
@@ -192,7 +186,6 @@ export function AutomationFunSection() {
   const [activeLang, setActiveLang] = useState("python");
   const [detection, setDetection] = useState<AutomationDetection | null>(null);
   const [haiku, setHaiku] = useState<ReturnType<typeof getRandomHaiku> | null>(null);
-  const [copiedMain, setCopiedMain] = useState(false);
   const [copiedCmd, setCopiedCmd] = useState<number | null>(null);
   const hasScrolledRef = useRef(false);
   const [ciJobUrls, setCiJobUrls] = useState<Record<string, string>>({});
@@ -258,14 +251,7 @@ export function AutomationFunSection() {
     }
   };
 
-  const handleCopy = () => {
-    navigator.clipboard.writeText(scriptData).then(() => {
-      setCopiedMain(true);
-      setTimeout(() => setCopiedMain(false), 1000);
-    });
-  };
-
-  const handleCmdCopy = (text: string, index: number) => {
+const handleCmdCopy = (text: string, index: number) => {
     navigator.clipboard.writeText(text).then(() => {
       setCopiedCmd(index);
       setTimeout(() => setCopiedCmd(null), 1000);
@@ -420,73 +406,107 @@ export function AutomationFunSection() {
               const currentCmdIndex = cmdIndex;
               cmdIndex++;
 
-              elements.push(
-                <div key={`cmd-${currentCmdIndex}`} className={styles["instrCmd"]}>
-                  <div className={styles["instrCmdLines"]}>
-                    {normalizedCmds.map((cmd, idx) => (
-                      <code key={idx}>{cmd}</code>
-                    ))}
+              type HeredocDef = { startsWith: string; lang: string; label: string };
+              const heredocTypes: HeredocDef[] = [
+                { startsWith: "<?xml", lang: "xml", label: "pom.xml" },
+                { startsWith: "const { defineConfig }", lang: "javascript", label: "cypress.config.js" },
+              ];
+              const heredoc = heredocTypes.find((h) => normalizedCmds.some((l) => l.trimStart().startsWith(h.startsWith)));
+              if (heredoc) {
+                const contentStart = normalizedCmds.findIndex((l) => l.trimStart().startsWith(heredoc.startsWith));
+                const eofIdx = normalizedCmds.findIndex((l) => l.trim() === "EOF");
+                const shellLines = normalizedCmds.slice(0, contentStart).join("\n");
+                const contentLines = normalizedCmds.slice(contentStart, eofIdx === -1 ? undefined : eofIdx).join("\n");
+                const afterLines = eofIdx !== -1 ? normalizedCmds.slice(eofIdx).join("\n") : "";
+                const shStyle = { background: "transparent", padding: 0, margin: 0, fontSize: "0.72rem", lineHeight: "1.7" };
+                const codeProps = { style: { fontFamily: "var(--font-space-mono)" } };
+                elements.push(
+                  <div key={`cmd-${currentCmdIndex}`} className={styles["instrCmd"]}>
+                    <div className={styles["instrCmdLines"]}>
+                      <SyntaxHighlighter language="bash" style={tomorrow} customStyle={shStyle} codeTagProps={codeProps}>{shellLines}</SyntaxHighlighter>
+                      <details className={styles["instrXmlDetails"]}>
+                        <summary className={styles["instrXmlSummary"]}>{heredoc.label} ▸</summary>
+                        <SyntaxHighlighter language={heredoc.lang} style={tomorrow} customStyle={{ ...shStyle, padding: "8px 0 0" }} codeTagProps={codeProps}>{contentLines}</SyntaxHighlighter>
+                      </details>
+                      {afterLines && <SyntaxHighlighter language="bash" style={tomorrow} customStyle={shStyle} codeTagProps={codeProps}>{afterLines}</SyntaxHighlighter>}
+                    </div>
+                    <button
+                      className={styles["instrCmdCopy"]}
+                      onClick={() => handleCmdCopy(allText, currentCmdIndex)}
+                      style={{ animation: copiedCmd === currentCmdIndex ? "copyExpand 0.3s ease-out forwards" : "none" }}
+                    >
+                      {copiedCmd === currentCmdIndex ? "Copied!" : "copy"}
+                    </button>
                   </div>
-                  <button
-                    className={styles["instrCmdCopy"]}
-                    onClick={() => handleCmdCopy(allText, currentCmdIndex)}
-                    style={{
-                      animation: copiedCmd === currentCmdIndex ? "copyExpand 0.3s ease-out forwards" : "none",
-                    }}
-                  >
-                    {copiedCmd === currentCmdIndex ? "Copied!" : "copy"}
-                  </button>
-                </div>
-              );
+                );
+              } else {
+                elements.push(
+                  <div key={`cmd-${currentCmdIndex}`} className={styles["instrCmd"]}>
+                    <div className={styles["instrCmdLines"]}>
+                      <SyntaxHighlighter language="bash" style={tomorrow} customStyle={{ background: "transparent", padding: 0, margin: 0, fontSize: "0.72rem", lineHeight: "1.7" }} codeTagProps={{ style: { fontFamily: "var(--font-space-mono)" } }}>
+                        {allText}
+                      </SyntaxHighlighter>
+                    </div>
+                    <button
+                      className={styles["instrCmdCopy"]}
+                      onClick={() => handleCmdCopy(allText, currentCmdIndex)}
+                      style={{ animation: copiedCmd === currentCmdIndex ? "copyExpand 0.3s ease-out forwards" : "none" }}
+                    >
+                      {copiedCmd === currentCmdIndex ? "Copied!" : "copy"}
+                    </button>
+                  </div>
+                );
+              }
               continue;
             }
 
-            elements.push(
-              <div key={i} className={styles["instrStep"]}>
-                {line}
-              </div>
-            );
-            i++;
+            const saveMatch = line.match(/save the script below to (\S+)/i);
+            if (saveMatch) {
+              const saveFilename = saveMatch[1]!;
+              const stepLabel = line.match(/^(\d+\.)/)?.[1] ?? "";
+              const heredocText = `cat > ${saveFilename} << 'EOF'\n${scriptData}\nEOF`;
+              const scriptCmdIndex = cmdIndex++;
+              elements.push(
+                <div key={i} className={styles["instrStep"]}>{stepLabel} Create {saveFilename}:</div>
+              );
+              i++;
+              elements.push(
+                <div key={`script-wrap-${i}`} className={styles["instrCmd"]}>
+                  <div className={styles["instrCmdLines"]} style={{ width: "100%" }}>
+                    <SyntaxHighlighter language="bash" style={tomorrow} customStyle={{ background: "transparent", padding: 0, margin: 0, fontSize: "0.72rem", lineHeight: "1.7" }} codeTagProps={{ style: { fontFamily: "var(--font-space-mono)" } }}>
+                      {`cat > ${saveFilename} << 'EOF'`}
+                    </SyntaxHighlighter>
+                    <details className={styles["instrXmlDetails"]}>
+                      <summary className={styles["instrXmlSummary"]}>{saveFilename} ▸</summary>
+                      <SyntaxHighlighter language={currentLang} style={tomorrow} customStyle={{ background: "transparent", padding: "8px 0 0", margin: 0, fontSize: "0.72rem", lineHeight: "1.7", maxHeight: "400px", overflow: "auto" }} codeTagProps={{ style: { fontFamily: "var(--font-space-mono)" } }}>
+                        {scriptData}
+                      </SyntaxHighlighter>
+                    </details>
+                    <SyntaxHighlighter language="bash" style={tomorrow} customStyle={{ background: "transparent", padding: 0, margin: 0, fontSize: "0.72rem", lineHeight: "1.7" }} codeTagProps={{ style: { fontFamily: "var(--font-space-mono)" } }}>
+                      {"EOF"}
+                    </SyntaxHighlighter>
+                  </div>
+                  <button
+                    className={styles["instrCmdCopy"]}
+                    onClick={() => handleCmdCopy(heredocText, scriptCmdIndex)}
+                    style={{ animation: copiedCmd === scriptCmdIndex ? "copyExpand 0.3s ease-out forwards" : "none" }}
+                  >
+                    {copiedCmd === scriptCmdIndex ? "Copied!" : "copy"}
+                  </button>
+                </div>
+              );
+            } else {
+              elements.push(
+                <div key={i} className={styles["instrStep"]}>
+                  {line}
+                </div>
+              );
+              i++;
+            }
           }
 
           return elements;
         })()}
-      </div>
-
-      <div className={styles["autoCodeWrap"]}>
-        <div className={styles["autoCodeHeader"]}>
-          <div className={styles["autoCodeLabel"]}>{filename}</div>
-          <button
-            className={styles["autoCopy"]}
-            onClick={handleCopy}
-            style={{
-              animation: copiedMain ? "copyExpand 0.3s ease-out forwards" : "none",
-            }}
-          >
-            {copiedMain ? "Copied!" : "copy"}
-          </button>
-        </div>
-        <SyntaxHighlighter
-          language={currentLang}
-          style={tomorrow}
-          customStyle={{
-            background: "transparent",
-            padding: "16px 20px",
-            fontSize: "clamp(0.6rem, 1.8vw, 0.72rem)",
-            lineHeight: "1.7",
-            margin: 0,
-            maxHeight: "450px",
-            overflow: "auto",
-          }}
-          codeTagProps={{
-            style: {
-              fontFamily: "var(--font-space-mono)",
-              fontSize: "0.72rem",
-            },
-          }}
-        >
-          {scriptData}
-        </SyntaxHighlighter>
       </div>
 
       <div

--- a/src/components/AutomationFun/AutomationFunSection.tsx
+++ b/src/components/AutomationFun/AutomationFunSection.tsx
@@ -317,7 +317,7 @@ const handleCmdCopy = (text: string, index: number) => {
           // Human state
           <>
             <p className={styles["autoDesc"]}>
-              Run this page through an automation tool — it detects which one you&apos;re using and serves a custom haiku. Pick your tool and language below to get a script to run.
+              This website fingerprints if your browser is being driven by an automation tool. Pick your tool and language below, run the script, and reload for your reward.
             </p>
 
             <div className={styles["autoStatus"]} data-detected="false">
@@ -329,7 +329,7 @@ const handleCmdCopy = (text: string, index: number) => {
                   Human detected
                 </div>
                 <div className={styles["autoStatusSub"]}>
-                  No automation tool found. Run a script below and reload.
+                  No automation tool found. Run one of the scripts below to receive your prize.
                 </div>
               </div>
             </div>

--- a/src/components/AutomationFun/AutomationFunSection.tsx
+++ b/src/components/AutomationFun/AutomationFunSection.tsx
@@ -241,7 +241,6 @@ export function AutomationFunSection() {
   const currentLang = langs.includes(activeLang) ? activeLang : (langs[0] || "python");
 
   const scriptData = (scripts[activeTool]?.[currentLang] || fallbackScripts[activeTool]?.[currentLang] || "");
-  const filename = scriptData.match(/^(?:\/\/|#) File: (.+)/m)?.[1] || "";
 
   const handleToolClick = (tool: string) => {
     setActiveTool(tool);

--- a/src/components/AutomationFun/AutomationFunSection.tsx
+++ b/src/components/AutomationFun/AutomationFunSection.tsx
@@ -316,7 +316,7 @@ const handleCmdCopy = (text: string, index: number) => {
           // Human state
           <>
             <p className={styles["autoDesc"]}>
-              This website fingerprints if your browser is being driven by an automation tool. Pick your tool and language below, run the script, and reload for your reward.
+              This website can detect if your browser is being driven by an automation tool. Pick a tool and language below, run the script through your automation tool, and claim your reward.
             </p>
 
             <div className={styles["autoStatus"]} data-detected="false">

--- a/src/components/AutomationFun/automation.module.css
+++ b/src/components/AutomationFun/automation.module.css
@@ -216,6 +216,28 @@
   }
 }
 
+
+.instrXmlDetails {
+  margin-top: 4px;
+}
+
+.instrXmlSummary {
+  font-family: var(--font-space-mono);
+  font-size: 0.68rem;
+  color: rgba(255, 255, 255, 0.5);
+  cursor: pointer;
+  user-select: none;
+  list-style: none;
+}
+
+.instrXmlSummary::-webkit-details-marker {
+  display: none;
+}
+
+.instrXmlDetails[open] .instrXmlSummary {
+  color: rgba(255, 255, 255, 0.8);
+}
+
 .instrCmdCopy {
   font-family: var(--font-space-mono);
   font-size: 0.6rem;
@@ -238,54 +260,6 @@
 }
 
 /* Code block wrapper */
-.autoCodeWrap {
-  border: 2px solid var(--border);
-  background: #1a1815;
-  margin-bottom: 20px;
-}
-
-.autoCodeHeader {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 8px 10px 8px 16px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
-  background: #1a1815;
-}
-
-.autoCodeLabel {
-  font-family: var(--font-space-mono);
-  font-size: 0.62rem;
-  font-weight: 700;
-  letter-spacing: 0.04em;
-  color: rgba(255, 255, 255, 0.3);
-  flex: 1;
-  min-width: 0;
-  margin-right: 12px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.autoCopy {
-  font-family: var(--font-space-mono);
-  font-size: 0.65rem;
-  font-weight: 700;
-  padding: 4px 10px;
-  background: transparent;
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  color: rgba(255, 255, 255, 0.5);
-  cursor: pointer;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  flex-shrink: 0;
-  transition: all 0.12s;
-}
-
-.autoCopy:hover {
-  background: rgba(255, 255, 255, 0.1);
-  color: #fff;
-}
 
 /* Syntax highlighter overrides */
 :global(.autoCode pre[class*="language-"]),

--- a/src/components/AutomationFun/automation.module.css
+++ b/src/components/AutomationFun/automation.module.css
@@ -148,9 +148,8 @@
 /* Instructions panel */
 .autoInstructions {
   border: 2px solid var(--border);
-  border-bottom: none;
   background: var(--bg);
-  padding: 32px 18px 16px 18px;
+  padding: 8px 18px 16px 18px;
   font-family: var(--font-space-mono);
   font-size: 0.72rem;
   line-height: 2;

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useState } from "react";
+
+export function ContactForm() {
+  const [status, setStatus] = useState<"idle" | "submitting" | "success" | "error">("idle");
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [message, setMessage] = useState("");
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setStatus("submitting");
+    try {
+      const res = await fetch("https://formspree.io/f/mjgljvad", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Accept: "application/json" },
+        body: JSON.stringify({ name, email, message }),
+      });
+      if (res.ok) {
+        setStatus("success");
+        setName(""); setEmail(""); setMessage("");
+      } else {
+        setStatus("error");
+      }
+    } catch {
+      setStatus("error");
+    }
+  };
+
+  const inputStyle: React.CSSProperties = {
+    width: "100%",
+    fontFamily: "var(--font-space-mono)",
+    fontSize: "0.78rem",
+    background: "var(--bg)",
+    border: "2px solid var(--border)",
+    color: "var(--fg)",
+    padding: "10px 12px",
+    outline: "none",
+    boxSizing: "border-box",
+    transition: "border-color 0.12s",
+  };
+
+  return (
+    <form onSubmit={handleSubmit} style={{ maxWidth: "520px", marginTop: "24px" }}>
+      {/* Honeypot — bots fill this, humans don't */}
+      <input type="text" name="_honey" style={{ display: "none" }} tabIndex={-1} autoComplete="off" />
+      <input type="text" name="_gotcha" style={{ display: "none" }} tabIndex={-1} autoComplete="off" />
+
+      <div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
+        <input
+          type="text"
+          placeholder="Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          required
+          style={inputStyle}
+          onFocus={(e) => (e.currentTarget.style.borderColor = "var(--accent)")}
+          onBlur={(e) => (e.currentTarget.style.borderColor = "var(--border)")}
+        />
+        <input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+          style={inputStyle}
+          onFocus={(e) => (e.currentTarget.style.borderColor = "var(--accent)")}
+          onBlur={(e) => (e.currentTarget.style.borderColor = "var(--border)")}
+        />
+        <textarea
+          placeholder="Message — or paste a script error here if something didn't work"
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          required
+          rows={5}
+          style={{ ...inputStyle, resize: "vertical" }}
+          onFocus={(e) => (e.currentTarget.style.borderColor = "var(--accent)")}
+          onBlur={(e) => (e.currentTarget.style.borderColor = "var(--border)")}
+        />
+        <button
+          type="submit"
+          disabled={status === "submitting"}
+          style={{
+            alignSelf: "flex-start",
+            fontFamily: "var(--font-space-mono)",
+            fontSize: "0.72rem",
+            fontWeight: 700,
+            letterSpacing: "0.08em",
+            textTransform: "uppercase",
+            padding: "10px 20px",
+            background: status === "success" ? "var(--fg)" : "var(--accent)",
+            color: "var(--bg)",
+            border: "none",
+            cursor: status === "submitting" ? "wait" : "pointer",
+            transition: "opacity 0.12s",
+            opacity: status === "submitting" ? 0.6 : 1,
+          }}
+        >
+          {status === "submitting" ? "Sending..." : status === "success" ? "Sent ✓" : "Send"}
+        </button>
+        {status === "error" && (
+          <p style={{ fontFamily: "var(--font-space-mono)", fontSize: "0.72rem", color: "var(--accent)", margin: 0 }}>
+            Something went wrong — try emailing directly at zach.attas@gmail.com
+          </p>
+        )}
+      </div>
+    </form>
+  );
+}

--- a/src/lib/sections.ts
+++ b/src/lib/sections.ts
@@ -2,6 +2,7 @@ import type { ComponentType } from "react";
 
 import About from "../../content/about.mdx";
 import AutomationFun from "../../content/automation-fun.mdx";
+import Contact from "../../content/contact.mdx";
 import Experience from "../../content/experience.mdx";
 import Speaking from "../../content/speaking.mdx";
 import Stories from "../../content/stories.mdx";
@@ -32,5 +33,11 @@ export const sections: SiteSection[] = [
     navLabel: "Automation Fun",
     anchor: "automation-fun",
     Content: AutomationFun,
+  },
+  {
+    indexLabel: "07",
+    navLabel: "Contact",
+    anchor: "contact",
+    Content: Contact,
   },
 ];


### PR DESCRIPTION
## Summary

### Instructions UI overhaul
- All shell command blocks now syntax-highlighted as bash
- `pom.xml` and `cypress.config.js` heredoc blocks collapsed behind a `<details>` toggle with XML/JS syntax highlighting
- "Save the script below" steps replaced with `cat > file << 'EOF'` heredoc blocks — script content collapsed and copyable as a full runnable heredoc, ready to paste directly into a terminal
- Copy button copies the complete heredoc including `cat` and `EOF` lines, not just the script
- Removed all `touch` lines from install steps
- Removed the separate bottom code block — script now lives inline in the steps
- Step labels changed from "Save to X" → "Create X" to match what the `cat` command actually does
- Trimmed extra top padding and restored bottom border on instructions panel
- Rewrote main description: "This website can detect if your browser is being driven by an automation tool. Pick a tool and language below, run the script through your automation tool, and claim your reward."
- Updated human-detected subtext to "Run one of the scripts below to receive your prize"

### Contact form
- New `ContactForm` component wired into `contact.mdx` as section 07
- Posts to Formspree (`mjgljvad`) with `application/json`
- Dual honeypot fields: `_honey` (Formspree's own) + `_gotcha` (catches Netlify-targeting bots)
- Accent-colored focus states, inline error fallback with direct email address
- Formshield ML filtering + CAPTCHA enabled in Formspree dashboard

### ci-matrix cache fix
- Reduced `Cache-Control` from `max-age=3600` to `max-age=300, stale-while-revalidate=600`
- Was serving stale CI run data for up to an hour after a new deploy completed

## Test plan
- [ ] Instructions render correctly for all tool/language combos — bash highlighting, collapsible heredocs
- [ ] Copy button on script blocks copies full `cat > file << 'EOF' ... EOF`
- [ ] Contact form submits successfully and email arrives
- [ ] Spam submissions with honeypot filled are rejected
- [ ] `/api/ci-matrix` reflects latest run within ~5 minutes of a deploy