### PR TITLE
Small tweaks: autoDesc wrap fix and cache header cleanup

### DIFF
--- a/src/app/api/ci-matrix/route.ts
+++ b/src/app/api/ci-matrix/route.ts
@@ -61,7 +61,7 @@ export async function GET() {
     { runUrl: latestRun.html_url, jobUrls },
     {
       headers: {
-        "Cache-Control": "public, max-age=300, stale-while-revalidate=600",
+        "Cache-Control": "public, max-age=300",
       },
     }
   );

--- a/src/components/AutomationFun/AutomationFunSection.tsx
+++ b/src/components/AutomationFun/AutomationFunSection.tsx
@@ -316,7 +316,7 @@ const handleCmdCopy = (text: string, index: number) => {
           // Human state
           <>
             <p className={styles["autoDesc"]}>
-              This website can detect if your browser is being driven by an automation tool. Pick a tool and language below, run the script through your automation tool, and claim your reward.
+              This website can detect if your browser is being driven by an automation tool.<br></br>Pick a tool and language below, run the script using that tool, and claim an AMAZING reward.
             </p>
 
             <div className={styles["autoStatus"]} data-detected="false">
@@ -328,7 +328,7 @@ const handleCmdCopy = (text: string, index: number) => {
                   Human detected
                 </div>
                 <div className={styles["autoStatusSub"]}>
-                  No automation tool found. Run one of the scripts below to receive your prize.
+                  No automation tool found.
                 </div>
               </div>
             </div>

--- a/src/components/AutomationFun/AutomationFunSection.tsx
+++ b/src/components/AutomationFun/AutomationFunSection.tsx
@@ -525,7 +525,7 @@ const handleCmdCopy = (text: string, index: number) => {
         )}
         <div className={styles["ciHeader"]}>
           <span className={styles["ciLabel"]}>CD matrix <span className={styles["ciLabelHint"]}>[?]</span></span>
-          <span className={styles["ciMeta"]}>triggered on every Vercel deploy · all passing</span>
+          <span className={styles["ciMeta"]}>triggered daily and on every Vercel deploy to production · all passing</span>
         </div>
         <div
           className={styles["ciGrid"]}

--- a/src/components/AutomationFun/automation.module.css
+++ b/src/components/AutomationFun/automation.module.css
@@ -13,7 +13,6 @@
   line-height: 1.75;
   color: var(--muted);
   margin-bottom: 24px;
-  max-width: 600px;
 }
 
 /* Status indicator */

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -69,7 +69,7 @@ export function ContactForm() {
           onBlur={(e) => (e.currentTarget.style.borderColor = "var(--border)")}
         />
         <textarea
-          placeholder="Message — or paste a script error here if something didn't work"
+          placeholder="Message in, or if one of the scripts didn't work for you, paste the error you received here"
           value={message}
           onChange={(e) => setMessage(e.target.value)}
           required


### PR DESCRIPTION
## Summary

- Remove `max-width: 600px` from `.autoDesc` — was causing awkward mid-sentence text wrap inside the automation container
- Drop `stale-while-revalidate=600` from ci-matrix `Cache-Control` — GitHub API responds fast enough that serving stale data for an extra 10 minutes adds no value

🤖 Generated with [Claude Code](https://claude.com/claude-code)