### PR TITLE
Add sparkle particle effect to nav Automation Fun label and disco mode

### DIFF
--- a/src/components/AutomationFun/AutomationFunSection.tsx
+++ b/src/components/AutomationFun/AutomationFunSection.tsx
@@ -188,6 +188,7 @@ export function AutomationFunSection() {
   const [detection, setDetection] = useState<AutomationDetection | null>(null);
   const [haiku, setHaiku] = useState<ReturnType<typeof getRandomHaiku> | null>(null);
   const [discoActive, setDiscoActive] = useState(false);
+  const discoTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [copiedCmd, setCopiedCmd] = useState<number | null>(null);
   const hasScrolledRef = useRef(false);
   const [ciJobUrls, setCiJobUrls] = useState<Record<string, string>>({});
@@ -228,18 +229,19 @@ export function AutomationFunSection() {
     setHaiku((prev) => prev ?? getRandomHaiku());
     setActiveTool(detection.tool ?? "playwright");
 
+    // Disco effect for 5 minutes — always on detection
+    document.body.classList.add("disco-active");
+    setDiscoActive(true);
+    if (discoTimerRef.current) clearTimeout(discoTimerRef.current);
+    discoTimerRef.current = setTimeout(() => {
+      document.body.classList.remove("disco-active");
+      setDiscoActive(false);
+    }, 300000);
+
     // Auto-scroll to section only on first detection
     if (!hasScrolledRef.current) {
       hasScrolledRef.current = true;
       document.getElementById("automation-fun")?.scrollIntoView({ block: "start" });
-
-      // Disco effect for 5 minutes
-      document.body.classList.add("disco-active");
-      setDiscoActive(true);
-      setTimeout(() => {
-        document.body.classList.remove("disco-active");
-        setDiscoActive(false);
-      }, 300000);
     }
   }, []);
 
@@ -265,7 +267,7 @@ const handleCmdCopy = (text: string, index: number) => {
 
   return (
     <section id="automation-fun">
-      {discoActive && <Sparkle mode="fullscreen" />}
+      {(discoActive || (detection && haiku)) && <Sparkle mode="fullscreen" />}
       <AutomationDetector onDetected={handleDetected} />
 
       <div className={styles["autoContainer"]}>

--- a/src/components/AutomationFun/AutomationFunSection.tsx
+++ b/src/components/AutomationFun/AutomationFunSection.tsx
@@ -7,6 +7,7 @@ import { tomorrow } from "react-syntax-highlighter/dist/esm/styles/prism";
 import { AutomationDetector, type AutomationDetection } from "./AutomationDetector";
 import { getRandomHaiku } from "@/data/haikus";
 import { galleryScripts } from "@/data/generatedGalleryScripts";
+import { Sparkle } from "@/components/Sparkle";
 import styles from "./automation.module.css";
 
 // Use pre-loaded scripts
@@ -186,6 +187,7 @@ export function AutomationFunSection() {
   const [activeLang, setActiveLang] = useState("python");
   const [detection, setDetection] = useState<AutomationDetection | null>(null);
   const [haiku, setHaiku] = useState<ReturnType<typeof getRandomHaiku> | null>(null);
+  const [discoActive, setDiscoActive] = useState(false);
   const [copiedCmd, setCopiedCmd] = useState<number | null>(null);
   const hasScrolledRef = useRef(false);
   const [ciJobUrls, setCiJobUrls] = useState<Record<string, string>>({});
@@ -233,7 +235,11 @@ export function AutomationFunSection() {
 
       // Disco effect for 5 minutes
       document.body.classList.add("disco-active");
-      setTimeout(() => document.body.classList.remove("disco-active"), 300000);
+      setDiscoActive(true);
+      setTimeout(() => {
+        document.body.classList.remove("disco-active");
+        setDiscoActive(false);
+      }, 300000);
     }
   }, []);
 
@@ -259,6 +265,7 @@ const handleCmdCopy = (text: string, index: number) => {
 
   return (
     <section id="automation-fun">
+      {discoActive && <Sparkle mode="fullscreen" />}
       <AutomationDetector onDetected={handleDetected} />
 
       <div className={styles["autoContainer"]}>

--- a/src/components/AutomationFun/AutomationFunSection.tsx
+++ b/src/components/AutomationFun/AutomationFunSection.tsx
@@ -325,7 +325,7 @@ const handleCmdCopy = (text: string, index: number) => {
           // Human state
           <>
             <p className={styles["autoDesc"]}>
-              This website can detect if your browser is being driven by an automation tool.<br></br>Pick a tool and language below, run the script using that tool, and claim an AMAZING reward.
+              This website can <b>detect if your browser is being driven by an automation tool</b>.<br></br>Pick a tool and language below, run the script using that tool, and claim an <b>AMAZING reward</b>.
             </p>
 
             <div className={styles["autoStatus"]} data-detected="false">
@@ -528,7 +528,7 @@ const handleCmdCopy = (text: string, index: number) => {
             style={{ left: ciTooltipPos.x + 14, top: ciTooltipPos.y + 14 }}
           >
             {ciGridHovered && <><span className={styles["ciTooltipClick"]}>click any row to open that job in github</span><br /></>}
-            every deploy triggers a full matrix of tests, verifying that each combo of automation tool and language correctly trips the detection logic, isn&apos;t mistaken for a human, and claims the AMAZING reward
+            every deploy triggers a full matrix of tests, verifying that each combo of automation tool and language correctly trips the detection logic, isn&apos;t mistaken for a human, and claims the <b>AMAZING reward</b>
           </div>,
           document.body
         )}

--- a/src/components/AutomationFun/AutomationFunSection.tsx
+++ b/src/components/AutomationFun/AutomationFunSection.tsx
@@ -527,7 +527,7 @@ const handleCmdCopy = (text: string, index: number) => {
             className={styles["ciTooltip"]}
             style={{ left: ciTooltipPos.x + 14, top: ciTooltipPos.y + 14 }}
           >
-            {ciGridHovered && <><span className={styles["ciTooltipClick"]}>click any row to open that run in github</span><br /></>}
+            {ciGridHovered && <><span className={styles["ciTooltipClick"]}>click any row to open that job in github</span><br /></>}
             every deploy triggers a full matrix of tests, verifying that each combo of automation tool and language correctly trips the detection logic, isn&apos;t mistaken for a human, and claims the AMAZING reward
           </div>,
           document.body

--- a/src/components/AutomationFun/AutomationFunSection.tsx
+++ b/src/components/AutomationFun/AutomationFunSection.tsx
@@ -528,7 +528,7 @@ const handleCmdCopy = (text: string, index: number) => {
             style={{ left: ciTooltipPos.x + 14, top: ciTooltipPos.y + 14 }}
           >
             {ciGridHovered && <><span className={styles["ciTooltipClick"]}>click any row to open that run in github</span><br /></>}
-            every deploy triggers a full matrix of tests, testing each combo of automation tool and language — all verified green before going live
+            every deploy triggers a full matrix of tests, verifying that each combo of automation tool and language correctly trips the detection logic, isn&apos;t mistaken for a human, and claims the AMAZING reward
           </div>,
           document.body
         )}

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import type { NavSection } from "@/lib/sections";
+import { Sparkle } from "@/components/Sparkle";
 
 export function Nav({ sections }: { sections: NavSection[] }) {
   return (
@@ -90,7 +91,7 @@ export function Nav({ sections }: { sections: NavSection[] }) {
                   {s.indexLabel}
                 </span>{" "}
                 {s.anchor === "automation-fun"
-                  ? <span className="nav-disco">{s.navLabel}</span>
+                  ? <span className="nav-disco"><Sparkle mode="inline" />{s.navLabel}</span>
                   : s.navLabel}
               </Link>
             </li>
@@ -110,6 +111,8 @@ export function Nav({ sections }: { sections: NavSection[] }) {
         }
         .nav-disco {
           animation: navDisco 3s linear infinite;
+          position: relative;
+          display: inline-block;
         }
         @media (max-width: 767px) {
           .nav-container {

--- a/src/components/Sparkle.tsx
+++ b/src/components/Sparkle.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+type SparkleMode = "inline" | "fullscreen";
+
+const COLORS = ["#e8500a", "#d4a017", "#2e9e4f", "#2176ae", "#7b3fa0", "#c0334d", "#fff"];
+
+function randomBetween(a: number, b: number) {
+  return a + Math.random() * (b - a);
+}
+
+function spawnSparkle(rect: DOMRect | null, mode: SparkleMode) {
+  const el = document.createElement("span");
+  const size = randomBetween(4, 9);
+  const color = COLORS[Math.floor(Math.random() * COLORS.length)]!;
+  const shape = Math.random() > 0.5 ? "50%" : "0%";
+
+  let x: number, y: number;
+  if (mode === "fullscreen" || !rect) {
+    x = randomBetween(0, window.innerWidth);
+    y = randomBetween(0, window.innerHeight);
+  } else {
+    x = randomBetween(rect.left, rect.right);
+    y = randomBetween(rect.top, rect.bottom);
+  }
+
+  const dx = randomBetween(-30, 30);
+  const dy = randomBetween(-50, -10);
+  const duration = randomBetween(600, 1100);
+
+  el.style.cssText = `
+    position: fixed;
+    left: ${x}px;
+    top: ${y}px;
+    width: ${size}px;
+    height: ${size}px;
+    background: ${color};
+    border-radius: ${shape};
+    pointer-events: none;
+    z-index: 9999;
+    opacity: 1;
+    transform: translate(0, 0) scale(1);
+    transition: transform ${duration}ms ease-out, opacity ${duration}ms ease-out;
+  `;
+
+  document.body.appendChild(el);
+  el.getBoundingClientRect();
+  el.style.transform = `translate(${dx}px, ${dy}px) scale(0)`;
+  el.style.opacity = "0";
+  setTimeout(() => el.remove(), duration);
+}
+
+export function Sparkle({ mode }: { mode: SparkleMode }) {
+  const anchorRef = useRef<HTMLSpanElement>(null);
+
+  useEffect(() => {
+    const rate = mode === "fullscreen" ? 80 : 250;
+    const count = mode === "fullscreen" ? 3 : 1;
+
+    const interval = setInterval(() => {
+      const rect = mode === "inline" && anchorRef.current
+        ? anchorRef.current.getBoundingClientRect()
+        : null;
+      for (let i = 0; i < count; i++) spawnSparkle(rect, mode);
+    }, rate);
+
+    return () => clearInterval(interval);
+  }, [mode]);
+
+  if (mode === "fullscreen") return null;
+
+  return <span ref={anchorRef} style={{ position: "absolute", inset: 0, pointerEvents: "none" }} />;
+}

--- a/src/components/Sparkle.tsx
+++ b/src/components/Sparkle.tsx
@@ -44,7 +44,7 @@ function spawnSparkle(rect: DOMRect | null, mode: SparkleMode) {
     transition: transform ${duration}ms ease-out, opacity ${duration}ms ease-out;
   `;
 
-  document.body.appendChild(el);
+  document.documentElement.appendChild(el);
   el.getBoundingClientRect();
   el.style.transform = `translate(${dx}px, ${dy}px) scale(0)`;
   el.style.opacity = "0";


### PR DESCRIPTION
- Sparkle component spawns fixed-position particles using getBoundingClientRect
- Inline mode: sparkles constrained to nav-disco span bounds
- Fullscreen mode: sparkles rain across entire viewport during bot-detected disco
- nav-disco set to inline-block + position relative so anchor fills correctly

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>