### PR TITLE
Redesign Speaking and Experience sections

### DIFF
--- a/content/experience.mdx
+++ b/content/experience.mdx
@@ -2,6 +2,7 @@
 
 <Timeline>
   <TimelineItem
+    num="E—01"
     title={
       <a
         href="https://www.capsule.com/"
@@ -10,61 +11,78 @@
         Capsule
       </a>
     }
+    subtitle="Staff Platform Engineer (Platform Lead)"
     startDate="2022-01-01"
     isCurrent={true}
     yearDisplay={true}
-    subtitle="Staff Platform Engineer"
     imageSrc="/images/experience/capsule.jpeg"
     imageAlt="Capsule"
+    hook="Built the AI-safety & release-gate platform a 20-deploy-a-day healthcare company quietly runs on."
+    stats={[
+      { v: "75%", k: "Fewer prod incidents" },
+      { v: "20+", k: "Daily deploys gated" },
+      { v: "3", k: "QA engineers hired" },
+      { v: "1st", k: "Formal QA process" }
+    ]}
   >
     <TimelineItemGroup title="AI & ARCHITECTURAL INITIATIVES">
-    <div style={{ display: "flex", gap: "0.5em", marginBottom: "1em" }}>
-      <span style={{ color: "var(--accent)", fontWeight: 700, flexShrink: 0 }}>–</span>
-      <div>Architected a **security-hardened MCP proxy** to gate 3rd-party and internal AI interactions, implementing automated **PII/PHI redaction, prompt injection protection, and RBAC/ABAC** for enterprise compliance</div>
-    </div>
-
-    <div style={{ display: "flex", gap: "0.5em", marginBottom: "1em" }}>
-      <span style={{ color: "var(--accent)", fontWeight: 700, flexShrink: 0 }}>–</span>
-      <div>Built an **AI voice agent** to automate patient onboarding, significantly reducing operational overhead while improving medication routing accuracy</div>
-    </div>
-
-    <div style={{ display: "flex", gap: "0.5em", marginBottom: "1em" }}>
-      <span style={{ color: "var(--accent)", fontWeight: 700, flexShrink: 0 }}>–</span>
-      <div>Led the migration of mission-critical workflows from a legacy in-house solution to [Temporal Cloud](https://temporal.io/), establishing a repeatable framework for all distributed services</div>
-    </div>
-
-    <div style={{ display: "flex", gap: "0.5em", marginBottom: "1em" }}>
-      <span style={{ color: "var(--accent)", fontWeight: 700, flexShrink: 0 }}>–</span>
-      <div>Engineered message-interception middleware for **SNS, SQS, and Kafka** to facilitate consumer-driven contract testing and support the transition to a **Saga-based architecture**</div>
-    </div>
+      <div style={{ display: "flex", gap: "0.5em", marginBottom: "1em" }}>
+        <span style={{ color: "var(--accent)", fontWeight: 700, flexShrink: 0 }}>–</span>
+        <div>Architected a **security-hardened MCP proxy** to gate 3rd-party and internal AI interactions, implementing automated **PII/PHI redaction, prompt injection protection, and RBAC/ABAC** to ensure enterprise compliance</div>
+      </div>
+      <div style={{ display: "flex", gap: "0.5em", marginBottom: "1em" }}>
+        <span style={{ color: "var(--accent)", fontWeight: 700, flexShrink: 0 }}>–</span>
+        <div>Built an **AI voice agent** to automate patient onboarding, significantly reducing operational overhead while improving medication routing accuracy</div>
+      </div>
+      <div style={{ display: "flex", gap: "0.5em", marginBottom: "1em" }}>
+        <span style={{ color: "var(--accent)", fontWeight: 700, flexShrink: 0 }}>–</span>
+        <div>Pioneered a **conversational AI triage agent** (Claude Agent SDK, multi-agent) that synthesizes code repository metadata (commits, PRs, version history) and codebase architecture with real-time test trends and cross-environment log data to **diagnose pipeline failures and surface SDLC bottlenecks**</div>
+      </div>
+      <div style={{ display: "flex", gap: "0.5em", marginBottom: "1em" }}>
+        <span style={{ color: "var(--accent)", fontWeight: 700, flexShrink: 0 }}>–</span>
+        <div>Owned the **end-to-end migration** of workflows to [Temporal Cloud](https://temporal.io/); acted as **sole architect and project manager** to establish the paved path for **distributed orchestration, built-in resiliency, and unified alerting**</div>
+      </div>
+      <div style={{ display: "flex", gap: "0.5em", marginBottom: "1em" }}>
+        <span style={{ color: "var(--accent)", fontWeight: 700, flexShrink: 0 }}>–</span>
+        <div>Engineered message-interception middleware for **SNS, SQS, and Kafka** to facilitate consumer-driven contract testing and support the transition to a **Saga-based architecture**</div>
+      </div>
     </TimelineItemGroup>
 
     <TimelineItemGroup title="QUALITY ENGINEERING & PLATFORM TOOLING">
-    <div style={{ display: "flex", gap: "0.5em", marginBottom: "1em" }}>
-      <span style={{ color: "var(--accent)", fontWeight: 700, flexShrink: 0 }}>–</span>
-      <div>Spearheaded Capsule's first E2E test suite (Python, Pytest, Playwright) — Release Gate for **20+ daily deployments**, reducing production incidents by **75%**</div>
-    </div>
-
-    <div style={{ display: "flex", gap: "0.5em", marginBottom: "1em" }}>
-      <span style={{ color: "var(--accent)", fontWeight: 700, flexShrink: 0 }}>–</span>
-      <div>Developed an internal data orchestration tool enabling engineers to **instantly provision specific test scenarios**, standardizing manual QA enterprise-wide</div>
-    </div>
+      <div style={{ display: "flex", gap: "0.5em", marginBottom: "1em" }}>
+        <span style={{ color: "var(--accent)", fontWeight: 700, flexShrink: 0 }}>–</span>
+        <div>Spearheaded the creation of Capsule's first end-to-end test suite (Python, Pytest, Playwright), serving as a Release Gate for **20+ daily deployments** and reducing production incidents by **75%**</div>
+      </div>
+      <div style={{ display: "flex", gap: "0.5em", marginBottom: "1em" }}>
+        <span style={{ color: "var(--accent)", fontWeight: 700, flexShrink: 0 }}>–</span>
+        <div>Developed an internal data orchestration tool that enables engineers to **instantly provision specific test scenarios**, standardizing manual QA enterprise-wide</div>
+      </div>
     </TimelineItemGroup>
 
     <TimelineItemGroup title="TECHNICAL LEADERSHIP & INFRASTRUCTURE">
-    <div style={{ display: "flex", gap: "0.5em", marginBottom: "1em" }}>
-      <span style={{ color: "var(--accent)", fontWeight: 700, flexShrink: 0 }}>–</span>
-      <div>Instituted Capsule's **first formal QA process** and hired a team of **3 QA engineers**, codifying unified test-quality metrics across the organization</div>
-    </div>
-
-    <div style={{ display: "flex", gap: "0.5em", marginBottom: "1em" }}>
-      <span style={{ color: "var(--accent)", fontWeight: 700, flexShrink: 0 }}>–</span>
-      <div>Directed cross-functional infrastructure lifecycles, including major **Spring Boot 3** and **Django** upgrades for all core services</div>
-    </div>
+      <div style={{ display: "flex", gap: "0.5em", marginBottom: "1em" }}>
+        <span style={{ color: "var(--accent)", fontWeight: 700, flexShrink: 0 }}>–</span>
+        <div>Instituted Capsule's **first formal QA process** and hired a team of **3 QA engineers**, codifying unified test-quality metrics across the organization</div>
+      </div>
+      <div style={{ display: "flex", gap: "0.5em", marginBottom: "1em" }}>
+        <span style={{ color: "var(--accent)", fontWeight: 700, flexShrink: 0 }}>–</span>
+        <div>Served as **Platform Lead** and sole engineer, balancing hands-on systems architecture with end-to-end project management, roadmap scoping, and stakeholder alignment across **6 cross-functional teams**</div>
+      </div>
     </TimelineItemGroup>
+
+    <PillGrid>
+      <Pill>Python</Pill>
+      <Pill>Kotlin</Pill>
+      <Pill>Temporal</Pill>
+      <Pill>Playwright</Pill>
+      <Pill>Kafka</Pill>
+      <Pill>MCP</Pill>
+      <Pill>Spring Boot</Pill>
+    </PillGrid>
   </TimelineItem>
 
   <TimelineItem
+    num="E—02"
     title={
       <a
         href="https://www.reviewtrackers.com/"
@@ -73,40 +91,53 @@
         ReviewTrackers
       </a>
     }
+    subtitle="Senior SDET → Lead SDET"
     startDate="2018-01-01"
     endDate="2022-01-01"
     yearDisplay={true}
-    subtitle="Senior SDET → Lead SDET"
     imageSrc="/images/experience/rt.svg"
     imageAlt="ReviewTrackers"
+    hook="Took an E2E suite from 15 hours to 7 minutes. Helped get the company acquired."
+    stats={[
+      { v: "15h→7m", k: "E2E suite runtime" },
+      { v: "30%", k: "Fewer critical bugs YoY" },
+      { v: "3×", k: "Peak-traffic load tested" },
+      { v: "3", k: "Direct reports" }
+    ]}
   >
     <div style={{ display: "flex", gap: "0.5em", marginBottom: "1em" }}>
       <span style={{ color: "var(--accent)", fontWeight: 700, flexShrink: 0 }}>–</span>
       <div>Scaled E2E suite (Ruby, RSpec, Selenium) from **15 hours** of parallelized execution to **7 minutes** of wall-clock time by migrating to a self-managed **Kubernetes Selenium Grid**</div>
     </div>
-
     <div style={{ display: "flex", gap: "0.5em", marginBottom: "1em" }}>
       <span style={{ color: "var(--accent)", fontWeight: 700, flexShrink: 0 }}>–</span>
       <div>Accelerated 3rd-party API verification by developing a custom **Sinatra/Redis mock server** with a dependency injection pattern for the core application</div>
     </div>
-
     <div style={{ display: "flex", gap: "0.5em", marginBottom: "1em" }}>
       <span style={{ color: "var(--accent)", fontWeight: 700, flexShrink: 0 }}>–</span>
       <div>Orchestrated **ephemeral cloud testing environments**, reducing critical bugs by **30% YoY** and directly supporting the company's [acquisition by InMoment](https://www.reviewtrackers.com/blog/reviewtrackers-acquired-by-inmoment/)</div>
     </div>
-
     <div style={{ display: "flex", gap: "0.5em", marginBottom: "1em" }}>
       <span style={{ color: "var(--accent)", fontWeight: 700, flexShrink: 0 }}>–</span>
       <div>Managed QA and DevOps departments, overseeing **3 direct reports** and setting strategic roadmaps for infrastructure and quality</div>
     </div>
-
     <div style={{ display: "flex", gap: "0.5em", marginBottom: "1em" }}>
       <span style={{ color: "var(--accent)", fontWeight: 700, flexShrink: 0 }}>–</span>
       <div>Validated system resilience for **3× peak traffic** on critical endpoints by architecting load tests with [Python and Locust](https://medium.com/reviewtrackers-engineering/our-load-testing-journey-with-locust-c599670bc41b)</div>
     </div>
+
+    <PillGrid>
+      <Pill>Ruby</Pill>
+      <Pill>Python</Pill>
+      <Pill>Kubernetes</Pill>
+      <Pill>Selenium</Pill>
+      <Pill>Locust</Pill>
+      <Pill>Docker</Pill>
+    </PillGrid>
   </TimelineItem>
 
   <TimelineItem
+    num="E—03"
     title={
       <a
         href="https://www.jellyvision.com/"
@@ -115,35 +146,46 @@
         Jellyvision
       </a>
     }
+    subtitle="SDET"
     startDate="2017-01-01"
     endDate="2018-01-01"
     yearDisplay={true}
-    subtitle="SDET"
     imageSrc="/images/experience/jellyvision.png"
     imageAlt="Jellyvision"
+    hook="Shipped Jellyvision's first CI/CD browser-testing pipeline."
+    stats={[
+      { v: "50%", k: "Test runtime reduction" },
+      { v: "1st", k: "CI/CD test pipeline" },
+      { v: "1st", k: "Analytics E2E suite" }
+    ]}
   >
     <div style={{ display: "flex", gap: "0.5em", marginBottom: "1em" }}>
       <span style={{ color: "var(--accent)", fontWeight: 700, flexShrink: 0 }}>–</span>
       <div>Deployed and maintained the **first CI/CD browser-testing pipeline** at Jellyvision, integrating automated quality gates into the standard deployment flow</div>
     </div>
-
     <div style={{ display: "flex", gap: "0.5em", marginBottom: "1em" }}>
       <span style={{ color: "var(--accent)", fontWeight: 700, flexShrink: 0 }}>–</span>
       <div>Reduced automated test runtime by **50%** through refactoring core engineering practices and optimizing wait-state logic</div>
     </div>
-
     <div style={{ display: "flex", gap: "0.5em", marginBottom: "1em" }}>
       <span style={{ color: "var(--accent)", fontWeight: 700, flexShrink: 0 }}>–</span>
       <div>Engineered the analytics team's **first E2E test suite** using **BrowserMob Proxy** to validate real-time event tracking and data integrity</div>
     </div>
-
     <div style={{ display: "flex", gap: "0.5em", marginBottom: "1em" }}>
       <span style={{ color: "var(--accent)", fontWeight: 700, flexShrink: 0 }}>–</span>
       <div>Developed the **first integration tests** for an ETL pipeline (**AWS Firehose, Lambda, CouchDB**), ensuring compliance with SLAs for critical customer analytics data</div>
     </div>
+
+    <PillGrid>
+      <Pill>Selenium</Pill>
+      <Pill>BrowserMob</Pill>
+      <Pill>AWS Lambda</Pill>
+      <Pill>CouchDB</Pill>
+    </PillGrid>
   </TimelineItem>
 
   <TimelineItem
+    num="E—04"
     title={
       <a
         href="https://www.facebook.com/robiniacourtyard/"
@@ -152,23 +194,22 @@
         Robinia Courtyard
       </a>
     }
+    subtitle="Prep Chef"
     startDate="2015-01-01"
     endDate="2016-01-01"
     yearDisplay={true}
-    subtitle="Prep Chef"
     imageSrc="/images/experience/robinia.jpg"
     imageAlt="Robinia Courtyard"
+    hook="Learned to code on stocks-and-mirepoix nights. Yes really."
   >
     <div style={{ display: "flex", gap: "0.5em", marginBottom: "1em" }}>
       <span style={{ color: "var(--accent)", fontWeight: 700, flexShrink: 0 }}>–</span>
       <div>Organized the walk-in, ground meat **daily**, cooked all house stocks</div>
     </div>
-
     <div style={{ display: "flex", gap: "0.5em", marginBottom: "1em" }}>
       <span style={{ color: "var(--accent)", fontWeight: 700, flexShrink: 0 }}>–</span>
       <div>Prepped ingredients and recipes for a **35+ item menu**</div>
     </div>
-
     <div style={{ display: "flex", gap: "0.5em", marginBottom: "1em" }}>
       <span style={{ color: "var(--accent)", fontWeight: 700, flexShrink: 0 }}>–</span>
       <div>Completed the **Intro to Programming** and [Full Stack Nanodegrees](https://www.udacity.com/course/full-stack-web-developer-nanodegree--nd0044) while working as a chef</div>
@@ -176,6 +217,7 @@
   </TimelineItem>
 
   <TimelineItem
+    num="E—05"
     title={
       <a
         href="https://www.epic.com/"
@@ -184,23 +226,22 @@
         Epic
       </a>
     }
+    subtitle="Quality Assurance"
     startDate="2013-01-01"
     endDate="2016-01-01"
     yearDisplay={true}
-    subtitle="Quality Assurance"
     imageSrc="/images/experience/epic.jpg"
     imageAlt="Epic"
+    hook="First QA job. Validated backend systems that touch patient care."
   >
     <div style={{ display: "flex", gap: "0.5em", marginBottom: "1em" }}>
       <span style={{ color: "var(--accent)", fontWeight: 700, flexShrink: 0 }}>–</span>
       <div>Validated core backend APIs for **batch scheduling, indexing, and HA failover** systems using the **Caché** programming language</div>
     </div>
-
     <div style={{ display: "flex", gap: "0.5em", marginBottom: "1em" }}>
       <span style={{ color: "var(--accent)", fontWeight: 700, flexShrink: 0 }}>–</span>
       <div>Automated **project grading** for the education team by developing a custom scripting utility to streamline internal review processes</div>
     </div>
-
     <div style={{ display: "flex", gap: "0.5em", marginBottom: "1em" }}>
       <span style={{ color: "var(--accent)", fontWeight: 700, flexShrink: 0 }}>–</span>
       <div>Managed the **RCA process** for high-priority technical issues, coordinating resolutions for low-level system failures affecting **patient care**</div>

--- a/content/speaking.mdx
+++ b/content/speaking.mdx
@@ -1,99 +1,84 @@
 # Speaking
 
-<Timeline>
-  <TimelineItem
-    title="Appium Conference"
-    createdDate="2021-09-01"
-    startDate="2021-09-01"
-    showCreated={false}
-    yearDisplay={true}
+<div className="speaking-stats">
+  <div><span className="v">8</span><span className="k">Talks</span></div>
+  <div><span className="v">5</span><span className="k">Conferences</span></div>
+  <div><span className="v">3</span><span className="k">Countries</span></div>
+</div>
+
+<TalkGrid>
+  <TalkCard
+    kind="Conference Talk"
+    date="Sep 2021"
+    conference="Appium Conf"
+    title="What else can we automate?"
+    href="https://confengine.com/conferences/appium-conf-2021/proposal/15905/what-else-can-we-automate-how-to-extend-your-skills-and-constantly-be-learning"
     imageSrc="/images/speaking/appiumconf.png"
     imageAlt="Appium Conference"
-  >
-    <a href="https://confengine.com/conferences/appium-conf-2021/proposal/15905/what-else-can-we-automate-how-to-extend-your-skills-and-constantly-be-learning" target="_blank" rel="noopener noreferrer" style={{ color: "var(--accent)", textDecoration: "none" }}>What else can we automate? How to extend your skills and constantly be learning</a>
-  </TimelineItem>
-
-  <TimelineItem
-    title="RabbitMQ Summit"
-    createdDate="2021-07-01"
-    startDate="2021-07-01"
-    showCreated={false}
-    yearDisplay={true}
+  />
+  <TalkCard
+    kind="Conference Talk"
+    date="Jul 2021"
+    conference="RabbitMQ Summit"
+    title="Take the path of least resistance for your test data"
+    href="https://www.youtube.com/watch?v=uAs1ot0zN7Y"
     imageSrc="/images/speaking/rabbitmq.png"
     imageAlt="RabbitMQ Summit"
-  >
-    <a href="https://www.youtube.com/watch?v=uAs1ot0zN7Y" target="_blank" rel="noopener noreferrer" style={{ color: "var(--accent)", textDecoration: "none" }}>Take The Path Of Least Resistance For Your Test Data</a>
-  </TimelineItem>
-
-  <TimelineItem
-    title="Testing United"
-    createdDate="2020-11-01"
-    startDate="2020-11-01"
-    showCreated={false}
-    yearDisplay={true}
+  />
+  <TalkCard
+    kind="Conference Talk"
+    date="Nov 2020"
+    conference="Testing United"
+    title="Setting yourself up for success so anyone can write tests"
+    href="https://web.archive.org/web/20201023112524/https://www.testingunited.com/speakers/zach-attas/"
     imageSrc="/images/speaking/testing_united.png"
     imageAlt="Testing United"
-  >
-    <a href="https://web.archive.org/web/20201023112524/https://www.testingunited.com/speakers/zach-attas/" target="_blank" rel="noopener noreferrer" style={{ color: "var(--accent)", textDecoration: "none" }}>Setting Yourself Up For Success So Anyone Can Understand And Write Tests</a>
-  </TimelineItem>
-
-  <TimelineItem
-    title="SeleniumConf India"
-    createdDate="2020-06-01"
-    startDate="2020-06-01"
-    showCreated={false}
-    yearDisplay={true}
+  />
+  <TalkCard
+    kind="Conference Talk"
+    date="Jun 2020"
+    conference="SeleniumConf India"
+    title="Selenium for all — setting your team up for success"
+    href="https://confengine.com/selenium-conf-2020/proposal/13759/selenium-for-all-setting-your-team-up-for-success-so-anyone-can-understand-and-write-tests"
     imageSrc="/images/speaking/seleniumconf.jpg"
-    imageAlt="SeleniumConf India"
+    imageAlt="SeleniumConf India 2020"
   >
-    <a href="https://confengine.com/selenium-conf-2020/proposal/13759/selenium-for-all-setting-your-team-up-for-success-so-anyone-can-understand-and-write-tests" target="_blank" rel="noopener noreferrer" style={{ color: "var(--accent)", textDecoration: "none" }}>Selenium For All - Setting Your Team Up For Success So Anyone Can Understand and Write Tests</a>
-
-    This talk was also presented at the <a href="https://www.continuoustestingmeetup.com/events/2020-07-29/" target="_blank" rel="noopener noreferrer" style={{ color: "var(--accent)", textDecoration: "none" }}>Berlin Continuous Testing Meetup</a>
-  </TimelineItem>
-
-  <TimelineItem
-    title="Quest For Quality"
-    createdDate="2019-11-01"
-    startDate="2019-11-01"
-    showCreated={false}
-    yearDisplay={true}
+    Also presented at the <a href="https://www.continuoustestingmeetup.com/events/2020-07-29/" target="_blank" rel="noopener noreferrer">Berlin Continuous Testing Meetup</a>.
+  </TalkCard>
+  <TalkCard
+    kind="Conference Talk"
+    date="Nov 2019"
+    conference="Quest For Quality"
+    title="Services: how to test them when you have the keys to the castle"
+    href="https://web.archive.org/web/20191209122733/https://www.questforquality.eu/speakers/zachary-attas/"
     imageSrc="/images/speaking/quest.jpg"
     imageAlt="Quest For Quality"
-  >
-    <a href="https://web.archive.org/web/20191209122733/https://www.questforquality.eu/speakers/zachary-attas/" target="_blank" rel="noopener noreferrer" style={{ color: "var(--accent)", textDecoration: "none" }}>Services: How to Test Them When You Have The Keys to The Castle</a>
-  </TimelineItem>
-
-  <TimelineItem
-    title="AgileTestingDays Chicago"
-    createdDate="2019-05-01"
-    startDate="2019-05-01"
-    showCreated={false}
-    yearDisplay={true}
+  />
+  <TalkCard
+    kind="Conference Talk"
+    date="May 2019"
+    conference="AgileTestingDays Chicago"
+    title="Flaky test or actual issue? You decide"
+    href="https://web.archive.org/web/20190718120434/https://agiletestingdays.us/session/flaky-test-or-actual-issue-you-decide/"
     imageSrc="/images/speaking/agiletestingdays.svg"
     imageAlt="AgileTestingDays Chicago"
-  >
-    <a href="https://web.archive.org/web/20190718120434/https://agiletestingdays.us/session/flaky-test-or-actual-issue-you-decide/" target="_blank" rel="noopener noreferrer" style={{ color: "var(--accent)", textDecoration: "none" }}>Flaky test or actual issue? You decide</a>
-  </TimelineItem>
-
-  <TimelineItem
-    title="SeleniumConf India"
-    createdDate="2018-06-01"
-    startDate="2018-06-01"
-    showCreated={false}
-    yearDisplay={true}
+  />
+  <TalkCard
+    kind="Conference Talk"
+    date="Jun 2018"
+    conference="SeleniumConf India"
+    title="How to unflake flaky tests — a new hire's toolkit"
+    href="https://confengine.com/selenium-conf-2018/proposal/6157/how-to-un-flake-flaky-tests-a-new-hires-toolkit"
     imageSrc="/images/speaking/seleniumconf.jpg"
-    imageAlt="SeleniumConf India"
-  >
-    <a href="https://confengine.com/selenium-conf-2018/proposal/6157/how-to-un-flake-flaky-tests-a-new-hires-toolkit" target="_blank" rel="noopener noreferrer" style={{ color: "var(--accent)", textDecoration: "none" }}>How to UnFlake Flaky Tests - a New Hire's Toolkit</a>
-  </TimelineItem>
-
-  <TimelineItem
-    title="The Ruby Testing Podcast by Jason Swett"
-    startDate="2018-01-01"
-    yearDisplay={true}
+    imageAlt="SeleniumConf India 2018"
+  />
+  <TalkCard
+    kind="Podcast"
+    date="Jan 2018"
+    conference="Ruby Testing Podcast"
+    title="QA, Selenium & SitePrism with Jason Swett"
+    href="https://podcast.app/selenium-and-qa-with-zach-attas-e39339212/"
     imageSrc="/images/speaking/rubytestingpodcast.jpg"
-    imageAlt="The Ruby Testing Podcast"
-  >
-    <a href="https://podcast.app/selenium-and-qa-with-zach-attas-e39339212/" target="_blank" rel="noopener noreferrer" style={{ color: "var(--accent)", textDecoration: "none" }}>Jason and I talk about QA, Selenium, and SitePrism</a>
-  </TimelineItem>
-</Timeline>
+    imageAlt="Ruby Testing Podcast"
+  />
+</TalkGrid>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -203,6 +203,64 @@ body.disco-active {
   z-index: 1;
 }
 
+/* Talk grid — speaking poster layout */
+.talk-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0;
+  margin-top: 28px;
+}
+
+@media (min-width: 600px) {
+  .talk-grid { grid-template-columns: 1fr 1fr; }
+}
+
+@media (min-width: 1000px) {
+  .talk-grid { grid-template-columns: 1fr 1fr 1fr; }
+}
+
+.talk-card:hover {
+  background: var(--surface);
+  position: relative;
+  z-index: 1;
+}
+
+/* Speaking stats hero */
+.speaking-stats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  border: 2px solid var(--border);
+  margin: 28px 0;
+}
+.speaking-stats > div {
+  padding: 18px 16px;
+  border-right: 2px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.speaking-stats > div:last-child { border-right: none; }
+.speaking-stats .v {
+  font-family: var(--font-syne);
+  font-weight: 800;
+  font-size: 1.8rem;
+  line-height: 1;
+  color: var(--accent);
+  letter-spacing: -0.03em;
+}
+.speaking-stats .k {
+  font-family: var(--font-space-mono);
+  font-size: 0.65rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+@media (max-width: 500px) {
+  .speaking-stats { grid-template-columns: 1fr 1fr; }
+  .speaking-stats > div:nth-child(odd) { border-right: 2px solid var(--border); }
+  .speaking-stats > div:last-child { border-right: none; grid-column: 1 / -1; }
+}
+
 .reveal p {
   margin-bottom: 1em;
   line-height: 1.7;

--- a/src/components/mdx/TalkCard.tsx
+++ b/src/components/mdx/TalkCard.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+export type TalkKind = "Conference Talk" | "Podcast" | "Meetup" | "Panel";
+
+export function TalkGrid({ children }: { children: ReactNode }) {
+  return <div className="talk-grid">{children}</div>;
+}
+
+export function TalkCard({
+  title,
+  conference,
+  href,
+  date,
+  kind = "Conference Talk",
+  imageSrc,
+  imageAlt,
+  logoMode,
+  children,
+}: {
+  title: string;
+  conference: string;
+  href?: string;
+  date: string;
+  kind?: TalkKind;
+  imageSrc: string;
+  imageAlt?: string;
+  logoMode?: boolean;
+  children?: ReactNode;
+}) {
+  const contain = logoMode ?? imageSrc.endsWith(".svg");
+
+  return (
+    <div
+      className="talk-card tilt-card reveal"
+      style={{
+        border: "2px solid var(--border)",
+        margin: "-1px 0 0 -1px",
+        background: "var(--bg)",
+        overflow: "hidden",
+        transition: "all 0.12s",
+        display: "flex",
+        flexDirection: "column",
+        height: "100%",
+      }}
+    >
+      <div
+        style={{
+          position: "relative",
+          width: "100%",
+          aspectRatio: "1 / 1",
+          borderBottom: "2px solid var(--border)",
+          background: contain ? "var(--bg)" : "var(--surface)",
+          overflow: "hidden",
+        }}
+      >
+        <Image
+          src={imageSrc}
+          alt={imageAlt ?? conference}
+          fill
+          sizes="(min-width: 900px) 33vw, (min-width: 600px) 50vw, 100vw"
+          style={{
+            objectFit: contain ? "contain" : "cover",
+            padding: contain ? "18px" : 0,
+          }}
+        />
+      </div>
+
+      <div
+        style={{
+          padding: "18px 20px 22px",
+          display: "flex",
+          flexDirection: "column",
+          gap: "8px",
+          flexGrow: 1,
+        }}
+      >
+        <div
+          style={{
+            fontFamily: "var(--font-space-mono)",
+            fontSize: "0.62rem",
+            fontWeight: 700,
+            letterSpacing: "0.14em",
+            textTransform: "uppercase",
+            color: "var(--accent)",
+          }}
+        >
+          {kind}
+        </div>
+        <div
+          style={{
+            fontFamily: "var(--font-space-mono)",
+            fontSize: "0.66rem",
+            color: "var(--muted)",
+            letterSpacing: "0.08em",
+            textTransform: "uppercase",
+          }}
+        >
+          {date} · {conference}
+        </div>
+        <h3
+          style={{
+            margin: "4px 0 0",
+            fontFamily: "var(--font-syne)",
+            fontWeight: 800,
+            fontSize: "1rem",
+            letterSpacing: "-0.01em",
+            lineHeight: 1.25,
+          }}
+        >
+          {title}
+        </h3>
+        {children ? (
+          <div
+            style={{
+              fontSize: "0.82rem",
+              color: "var(--muted)",
+              lineHeight: 1.5,
+              marginTop: "4px",
+            }}
+          >
+            {children}
+          </div>
+        ) : null}
+        {href ? (
+          <Link
+            href={href}
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{
+              marginTop: "auto",
+              paddingTop: "14px",
+              fontFamily: "var(--font-space-mono)",
+              fontSize: "0.7rem",
+              fontWeight: 700,
+              letterSpacing: "0.1em",
+              color: "var(--fg)",
+              textDecoration: "none",
+              alignSelf: "flex-end",
+            }}
+          >
+            {kind === "Podcast" ? "LISTEN ↗" : "VIEW ↗"}
+          </Link>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/components/mdx/Timeline.tsx
+++ b/src/components/mdx/Timeline.tsx
@@ -6,31 +6,25 @@ import { createPortal } from "react-dom";
 import Image from "next/image";
 
 export function Timeline({ children }: { children: ReactNode }) {
-  return <div style={{ marginTop: "24px" }}>{children}</div>;
+  return <div className="timeline" style={{ marginTop: "24px" }}>{children}</div>;
 }
 
-function formatDate(
-  date: Date,
-  monthDisplay: boolean,
-  yearDisplay: boolean
-): string {
-  if (yearDisplay) {
-    return date.toLocaleDateString("en-US", { year: "numeric" });
-  }
+function parseDateString(dateStr: string): Date {
+  const parts = dateStr.split("-");
+  const year = parseInt(parts[0] || "0", 10);
+  const month = parseInt(parts[1] || "1", 10);
+  const day = parseInt(parts[2] || "1", 10);
+  return new Date(year, month - 1, day);
+}
+
+function formatDate(date: Date, monthDisplay: boolean, yearDisplay: boolean): string {
+  if (yearDisplay) return date.toLocaleDateString("en-US", { year: "numeric" });
   if (monthDisplay) {
     const month = date.toLocaleDateString("en-US", { month: "short" });
     const year = date.toLocaleDateString("en-US", { year: "2-digit" });
     return `${month} '${year}`;
   }
   return date.toLocaleDateString("en-US", { year: "numeric" });
-}
-
-function parseDateString(dateStr: string): Date {
-  const parts = dateStr.split('-');
-  const year = parseInt(parts[0] || '0', 10);
-  const month = parseInt(parts[1] || '1', 10);
-  const day = parseInt(parts[2] || '1', 10);
-  return new Date(year, month - 1, day);
 }
 
 function formatDateRange(
@@ -40,46 +34,95 @@ function formatDateRange(
   createdDate: string = "",
   monthDisplay: boolean = true,
   yearDisplay: boolean = false,
-  showCreated: boolean = true
+  showCreated: boolean = true,
 ): string | null {
   if (createdDate) {
     const date = parseDateString(createdDate);
     const formattedDate = formatDate(date, monthDisplay, yearDisplay);
     return showCreated ? `Created ${formattedDate}` : formattedDate;
   }
-
   const start = parseDateString(startDate);
   const startFormatted = formatDate(start, monthDisplay, yearDisplay);
-
-  if (isCurrent) {
-    return `${startFormatted} - Present`;
-  }
-
+  if (isCurrent) return `${startFormatted} — Present`;
   if (endDate) {
     const end = parseDateString(endDate);
     const endFormatted = formatDate(end, monthDisplay, yearDisplay);
-    return `${startFormatted} - ${endFormatted}`;
+    return `${startFormatted} — ${endFormatted}`;
   }
-
   return startFormatted;
 }
 
 export function TimelineItemGroup({ title, children }: { title: string; children: ReactNode }) {
   return (
-    <div style={{ marginTop: "16px", marginBottom: "4px" }}>
+    <div style={{ marginTop: "20px", marginBottom: "4px" }}>
       <div
         style={{
           fontFamily: "var(--font-space-mono)",
           fontSize: "0.65rem",
           fontWeight: 700,
-          letterSpacing: "0.1em",
+          letterSpacing: "0.12em",
           textTransform: "uppercase",
           color: "var(--accent)",
+          marginBottom: "8px",
         }}
       >
         {title}
       </div>
       {children}
+    </div>
+  );
+}
+
+export type Stat = { v: ReactNode; k: string };
+
+function StatGrid({ stats }: { stats: Stat[] }) {
+  if (!stats || stats.length === 0) return null;
+  return (
+    <div
+      className="tl-stats"
+      style={{
+        display: "grid",
+        gridTemplateColumns: `repeat(${stats.length}, 1fr)`,
+        border: "2px solid var(--border)",
+        marginBottom: "20px",
+      }}
+    >
+      <style>{`
+        @media (max-width: 700px) {
+          .tl-stats { grid-template-columns: repeat(2, 1fr) !important; }
+        }
+        .tl-stat { padding: 18px 16px; border-right: 2px solid var(--border); }
+        .tl-stat:last-child { border-right: none; }
+        @media (max-width: 700px) {
+          .tl-stat { border-right: none !important; border-bottom: 2px solid var(--border); }
+          .tl-stat:nth-child(odd) { border-right: 2px solid var(--border) !important; }
+          .tl-stat:nth-last-child(-n+2):nth-child(even) { border-bottom: none; }
+          .tl-stat:last-child { border-bottom: none; }
+        }
+        .tl-stat .v {
+          font-family: var(--font-syne);
+          font-weight: 800;
+          font-size: clamp(1.5rem, 2.6vw, 2rem);
+          line-height: 1;
+          color: var(--accent);
+          letter-spacing: -0.03em;
+        }
+        .tl-stat .k {
+          font-family: var(--font-space-mono);
+          font-size: 0.62rem;
+          letter-spacing: 0.1em;
+          text-transform: uppercase;
+          color: var(--muted);
+          margin-top: 8px;
+          line-height: 1.4;
+        }
+      `}</style>
+      {stats.map((s, i) => (
+        <div className="tl-stat" key={i}>
+          <div className="v">{s.v}</div>
+          <div className="k">{s.k}</div>
+        </div>
+      ))}
     </div>
   );
 }
@@ -96,6 +139,11 @@ function TimelineItemContent({
   showCreated = true,
   imageSrc,
   imageAlt,
+  logoMode,
+  hook,
+  stats,
+  defaultOpen,
+  num,
   children,
 }: {
   title: ReactNode;
@@ -109,104 +157,167 @@ function TimelineItemContent({
   showCreated?: boolean;
   imageSrc?: string;
   imageAlt?: string;
+  logoMode?: boolean;
+  hook?: string;
+  stats?: Stat[];
+  defaultOpen?: boolean;
+  num?: string;
   children?: ReactNode;
 }) {
+  const [open, setOpen] = useState<boolean>(defaultOpen ?? isCurrent);
   const [showPreview, setShowPreview] = useState(false);
   const [mounted, setMounted] = useState(false);
 
   // eslint-disable-next-line react-hooks/set-state-in-effect -- standard SSR hydration guard
   useEffect(() => { setMounted(true); }, []);
+
   const dateRange = formatDateRange(startDate, endDate, isCurrent, createdDate, monthDisplay, yearDisplay, showCreated);
+  const contain = logoMode ?? (imageSrc?.endsWith(".svg") ?? false);
 
   return (
     <div
-      className="tl-item"
-      onMouseEnter={() => setShowPreview(true)}
-      onMouseLeave={() => setShowPreview(false)}
+      className={`tl-row ${open ? "open" : ""}`}
       style={{
-        padding: "24px 0",
-        borderTop: "2px solid var(--border)",
-        display: "grid",
-        gridTemplateColumns: "1fr",
-        gap: "12px",
+        border: "2px solid var(--border)",
+        margin: "-2px 0 0",
+        background: open ? "var(--surface)" : "var(--bg)",
+        transition: "background 0.18s",
       }}
     >
       <style>{`
-        @media (min-width: 900px) {
-          .tl-item {
-            grid-template-columns: 180px 1fr !important;
-            gap: 0 40px !important;
-          }
-          .tl-left { grid-column: 1; }
-          .tl-body { grid-column: 2; }
+        .tl-row .tl-head {
+          display: grid;
+          grid-template-columns: 56px 64px 1fr auto 28px;
+          gap: 0 18px;
+          align-items: center;
+          padding: 18px 22px;
+          cursor: pointer;
+          background: none;
+          border: none;
+          width: 100%;
+          text-align: left;
+          color: inherit;
+          font: inherit;
         }
-        @media (max-width: 899px) {
-          .tl-preview {
-            display: none !important;
+        @media (max-width: 760px) {
+          .tl-row .tl-head {
+            grid-template-columns: 56px 1fr 28px;
+            row-gap: 8px;
           }
+          .tl-row .tl-num-cell { grid-column: 2; grid-row: 1; }
+          .tl-row .tl-titlewrap { grid-column: 2; grid-row: 2; }
+          .tl-row .tl-date-cell { grid-column: 1 / 4; grid-row: 3; }
+          .tl-row .tl-chev-cell { grid-column: 3; grid-row: 1; }
+        }
+        .tl-logo {
+          width: 56px;
+          height: 56px;
+          border: 2px solid var(--border);
+          background: var(--bg);
+          overflow: hidden;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          position: relative;
+        }
+        .tl-num-cell {
+          font-family: var(--font-space-mono);
+          font-size: 0.7rem;
+          color: var(--accent);
+          letter-spacing: 0.1em;
+          font-weight: 700;
+        }
+        .tl-co {
+          font-family: var(--font-syne);
+          font-weight: 800;
+          font-size: 1.05rem;
+          letter-spacing: -0.01em;
+          line-height: 1.2;
+        }
+        .tl-co a { color: var(--fg) !important; text-decoration: none !important; transition: color 0.12s; }
+        .tl-co a:hover { color: var(--accent) !important; }
+        .tl-role {
+          font-family: var(--font-space-mono);
+          font-size: 0.7rem;
+          color: var(--muted);
+          letter-spacing: 0.04em;
+          margin-top: 3px;
+        }
+        .tl-hook {
+          font-family: var(--font-space-mono);
+          font-style: italic;
+          font-size: 0.78rem;
+          color: var(--muted);
+          margin-top: 8px;
+          line-height: 1.5;
+        }
+        .tl-date-cell {
+          font-family: var(--font-space-mono);
+          font-size: 0.72rem;
+          color: var(--muted);
+          white-space: nowrap;
+          text-align: right;
+        }
+        .tl-chev-cell {
+          font-family: var(--font-space-mono);
+          font-size: 1.1rem;
+          color: var(--accent);
+          text-align: center;
+          font-weight: 700;
+        }
+        .tl-body {
+          padding: 4px 22px 28px;
+          overflow: hidden;
+          transition: opacity 0.25s;
+        }
+        .tl-body p { margin: 0 0 0.85em; }
+        @media (max-width: 899px) {
+          .tl-preview { display: none !important; }
         }
       `}</style>
 
-      <div className="tl-left" style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
-        <div
-          className="tl-date"
-          style={{
-            fontFamily: "var(--font-space-mono)",
-            fontSize: "0.72rem",
-            color: "var(--muted)",
-            letterSpacing: "0.04em",
-          }}
-        >
-          {dateRange}
+      <button
+        type="button"
+        className="tl-head"
+        onClick={() => setOpen((o) => !o)}
+        onMouseEnter={() => setShowPreview(true)}
+        onMouseLeave={() => setShowPreview(false)}
+        aria-expanded={open}
+      >
+        <div className="tl-logo">
+          {imageSrc ? (
+            <Image
+              src={imageSrc}
+              alt={imageAlt ?? ""}
+              width={56}
+              height={56}
+              style={{
+                width: "100%",
+                height: "100%",
+                objectFit: contain ? "contain" : "cover",
+                padding: contain ? "6px" : 0,
+              }}
+            />
+          ) : null}
         </div>
-        <div
-          className="tl-company"
-          style={{
-            fontFamily: "var(--font-syne)",
-            fontWeight: 700,
-            fontSize: "1rem",
-          }}
-        >
-          <style>{`
-            .tl-company a {
-              color: var(--fg) !important;
-              text-decoration: none !important;
-              transition: color 0.12s;
-            }
-            .tl-company a:hover {
-              color: var(--accent) !important;
-            }
-          `}</style>
-          {title}
+        <div className="tl-num-cell">{num}</div>
+        <div className="tl-titlewrap">
+          <div className="tl-co">{title}</div>
+          {subtitle ? <div className="tl-role">{subtitle}</div> : null}
+          {hook ? <div className="tl-hook">&ldquo;{hook}&rdquo;</div> : null}
         </div>
-        {subtitle ? (
-          <div
-            className="tl-role"
-            style={{
-              fontFamily: "var(--font-space-mono)",
-              fontSize: "0.72rem",
-              color: "var(--muted)",
-            }}
-          >
-            {subtitle}
-          </div>
-        ) : null}
-      </div>
+        <div className="tl-date-cell">{dateRange}</div>
+        <div className="tl-chev-cell">{open ? "–" : "+"}</div>
+      </button>
 
-      {children ? (
-        <div
-          className="tl-body"
-          style={{
-            fontSize: "1rem",
-            lineHeight: 1.7,
-            color: "var(--muted)",
-          }}
-        >
+      {open ? (
+        <div className="tl-body">
+          {stats && stats.length > 0 ? <StatGrid stats={stats} /> : null}
           {children}
         </div>
       ) : null}
 
-      {imageSrc && mounted
+      {imageSrc && mounted && !open
         ? createPortal(
             <div
               className="tl-preview"
@@ -231,7 +342,7 @@ function TimelineItemContent({
                 style={{ width: "100%", height: "auto", display: "block" }}
               />
             </div>,
-            document.body
+            document.body,
           )
         : null}
     </div>

--- a/src/mdx-components.tsx
+++ b/src/mdx-components.tsx
@@ -2,6 +2,7 @@ import type { MDXComponents } from "mdx/types";
 import type { ComponentProps } from "react";
 
 import { Timeline, TimelineItem, TimelineItemGroup } from "@/components/mdx/Timeline";
+import { TalkCard, TalkGrid } from "@/components/mdx/TalkCard";
 import { ProjectCard } from "@/components/mdx/ProjectCard";
 import { Disclosure } from "@/components/mdx/Disclosure";
 import { Headshot } from "@/components/mdx/Headshot";
@@ -48,6 +49,8 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
     DetailPill,
     StoryCard,
     AutomationFunSection,
+    TalkCard,
+    TalkGrid,
     ...components,
   };
 }


### PR DESCRIPTION
## Summary

- **Speaking**: replaced `<Timeline>` with a new `<TalkGrid>` / `<TalkCard>` poster grid — square header images (cover for photos, contain for SVGs), kind badge (Conference Talk / Podcast), date · conference meta, VIEW/LISTEN link, and a stats hero (8 Talks / 5 Conferences / 3 Countries)
- **Experience**: refactored `TimelineItem` to a collapsible A+B hybrid — logo chip, numbered entry (`E—01`…`E—05`), italic hook quote, and `+`/`–` chevron in the collapsed header; expanded state reveals a stats grid + grouped bullets + tech pills. Capsule open by default.
- **Capsule entry updates**: subtitle → `Staff Platform Engineer (Platform Lead)`, new conversational AI triage agent bullet (Claude Agent SDK, multi-agent), revised Temporal Cloud framing as sole architect/PM, "6 cross-functional teams" stakeholder bullet replacing the Spring Boot infra line

## New files
- `src/components/mdx/TalkCard.tsx` — `TalkCard` + `TalkGrid` components

## Files changed
- `src/components/mdx/Timeline.tsx` — full A+B hybrid refactor
- `src/mdx-components.tsx` — registered `TalkCard` and `TalkGrid`
- `src/app/globals.css` — `.talk-grid`, `.talk-card:hover`, `.speaking-stats` rules
- `content/speaking.mdx` — replaced with TalkGrid
- `content/experience.mdx` — all entries get `num`, `hook`, `stats`; Capsule bullets updated

## Test plan
- [ ] Speaking renders 8 cards in 3-col grid (2-col tablet, 1-col mobile); AgileTestingDays SVG is centered with padding
- [ ] Stats hero shows 8 / 5 / 3
- [ ] Experience shows 5 rows; Capsule open by default with stats grid and grouped bullets
- [ ] Collapsed rows show logo chip, hook quote, date, `+` chevron; clicking expands/collapses
- [ ] Desktop hover preview appears top-right only on collapsed rows
- [ ] No console errors or layout shift

🤖 Generated with [Claude Code](https://claude.com/claude-code)