### PR TITLE
Add Person and WebSite JSON-LD for Google search thumbnails

### DIFF
--- a/content/about.mdx
+++ b/content/about.mdx
@@ -2,7 +2,7 @@
 
 <div className="not-prose mt-8 grid gap-10 md:grid-cols-[180px_1fr] md:items-start">
   <div>
-    <Headshot src="/images/headshot.png" alt="Zach Attas" />
+    <Headshot src="/images/headshot.png" alt="Headshot of Zach Attas, Staff Platform Engineer at Capsule, based in Chicago" />
 
     <div className="mt-4 flex flex-wrap justify-center gap-3">
       <a
@@ -22,7 +22,7 @@
         <img src="/icons/github.svg" alt="GitHub" className="h-5 w-5" />
       </a>
       <a
-        href="https://www.linkedin.com/in/zachary-attas-79b9a153"
+        href="https://www.linkedin.com/in/zachary-attas"
         target="_blank"
         rel="noopener noreferrer"
         aria-label="LinkedIn"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,46 @@ import { Footer } from "@/components/Footer";
 import { Section } from "@/components/Section";
 import { ClientInteractions } from "@/components/ClientInteractions";
 
+const personJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "Person",
+  name: "Zachary Attas",
+  alternateName: "Zach Attas",
+  url: "https://zattas.me",
+  image: "https://zattas.me/images/headshot.png",
+  jobTitle: "Staff Platform Engineer",
+  worksFor: {
+    "@type": "Organization",
+    name: "Capsule",
+    url: "https://www.capsule.com/",
+  },
+  address: {
+    "@type": "PostalAddress",
+    addressLocality: "Chicago",
+    addressRegion: "IL",
+    addressCountry: "US",
+  },
+  sameAs: [
+    "https://www.linkedin.com/in/zachary-attas",
+    "https://github.com/snackattas",
+    "https://medium.com/@zach.attas",
+    "https://confengine.com/user/zachary-attas",
+  ],
+};
+
+const websiteJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  name: "Zach Attas",
+  url: "https://zattas.me",
+  image: "https://zattas.me/og-image.png",
+  author: {
+    "@type": "Person",
+    name: "Zachary Attas",
+    url: "https://zattas.me",
+  },
+};
+
 export default function Home() {
   const navSections = sections.map(({ indexLabel, navLabel, anchor }) => ({
     indexLabel,
@@ -15,6 +55,14 @@ export default function Home() {
 
   return (
     <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(personJsonLd) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteJsonLd) }}
+      />
       {/* Sticky nav */}
       <Nav sections={navSections} />
 

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -5,7 +5,7 @@ import Image from "next/image";
 const SOCIAL_LINKS = [
   { href: "mailto:zach.attas@gmail.com", label: "Email", icon: "/icons/mail.svg" },
   { href: "https://github.com/snackattas", label: "GitHub", icon: "/icons/github.svg" },
-  { href: "https://www.linkedin.com/in/zachary-attas-79b9a153", label: "LinkedIn", icon: "/icons/linkedin.svg" },
+  { href: "https://www.linkedin.com/in/zachary-attas", label: "LinkedIn", icon: "/icons/linkedin.svg" },
   { href: "https://www.google.com/maps/place/Chicago,+IL", label: "Chicago on Google Maps", icon: "/icons/map-pin.svg" },
   { href: "https://medium.com/@zach.attas", label: "Medium", icon: "/icons/medium.svg" },
 ];


### PR DESCRIPTION
## Summary
- Adds `Person` JSON-LD to the homepage so Google has an authoritative entity + headshot it can attach to search results for queries about Zach
- Adds `WebSite` JSON-LD referencing `og-image.png` for broader SERP eligibility (sitelinks, brand box)
- Shortens LinkedIn URL to the vanity slug (`/in/zachary-attas`) in the Person schema, Hero socials, and About section
- Strengthens the About headshot alt text from `"Zach Attas"` to a descriptive variant matching the entity in the schema

## Notes
- OG image tags already cover social previews (Slack/LinkedIn/X); JSON-LD is the missing piece for Google search thumbnails
- Google takes days–weeks to recrawl/reindex before any thumbnail can appear, and it always reserves the right not to show one
- `Person.image` is the headshot (entity photo); `WebSite.image` is the og brand image — they don't conflict
- Markup can be validated post-deploy at https://search.google.com/test/rich-results

## Test plan
- [x] Preview deploy renders both `<script type="application/ld+json">` blocks in the rendered HTML
- [x] Rich Results Test passes for both schemas with no errors
- [x] LinkedIn link in hero + about + schema all resolve to the live profile
- [x] About-section headshot still renders with updated alt