### PR TITLE
Show real CI job conclusions and stale-green indicator

### DIFF
--- a/src/app/api/ci-matrix/route.ts
+++ b/src/app/api/ci-matrix/route.ts
@@ -7,6 +7,8 @@ const headers: HeadersInit = {
   Accept: "application/vnd.github+json",
 };
 
+type JobConclusion = "success" | "failure" | "cancelled" | "skipped" | "in_progress" | "unknown";
+
 export async function GET() {
   const workflowsRes = await fetch(
     `https://api.github.com/repos/${REPO}/actions/workflows`,
@@ -24,19 +26,29 @@ export async function GET() {
     return NextResponse.json({ error: "Workflow not found" }, { status: 404 });
   }
 
-  const runsRes = await fetch(
-    `https://api.github.com/repos/${REPO}/actions/workflows/${workflow.id}/runs?branch=main&per_page=1&status=success`,
-    { headers }
-  );
-  if (!runsRes.ok) {
+  const [latestRes, lastSuccessRes] = await Promise.all([
+    fetch(
+      `https://api.github.com/repos/${REPO}/actions/workflows/${workflow.id}/runs?branch=main&per_page=1`,
+      { headers }
+    ),
+    fetch(
+      `https://api.github.com/repos/${REPO}/actions/workflows/${workflow.id}/runs?branch=main&per_page=1&status=success`,
+      { headers }
+    ),
+  ]);
+
+  if (!latestRes.ok) {
     return NextResponse.json({ error: "Failed to fetch runs" }, { status: 502 });
   }
 
-  const runsData = await runsRes.json();
-  const latestRun = runsData.workflow_runs?.[0];
+  const latestData = await latestRes.json();
+  const latestRun = latestData.workflow_runs?.[0];
   if (!latestRun) {
     return NextResponse.json({ error: "No runs found" }, { status: 404 });
   }
+
+  const lastSuccessData = lastSuccessRes.ok ? await lastSuccessRes.json() : null;
+  const lastSuccessRun = lastSuccessData?.workflow_runs?.[0] ?? null;
 
   const jobsRes = await fetch(
     `https://api.github.com/repos/${REPO}/actions/runs/${latestRun.id}/jobs?per_page=100`,
@@ -47,18 +59,45 @@ export async function GET() {
   }
 
   const jobsData = await jobsRes.json();
-  const jobUrls: Record<string, string> = {};
+  const jobs: Record<string, { url: string; conclusion: JobConclusion }> = {};
 
   for (const job of jobsData.jobs ?? []) {
     // job.name format: "test (javascript, selenium, chrome)"
     const match = (job.name as string).match(/^test \((\w+), (\w+), \w+\)$/);
-    if (match) {
-      jobUrls[`${match[1]}-${match[2]}`] = job.html_url;
-    }
+    if (!match) continue;
+
+    const status = job.status as string;
+    const rawConclusion = job.conclusion as string | null;
+    const conclusion: JobConclusion =
+      status !== "completed"
+        ? "in_progress"
+        : rawConclusion === "success" ||
+            rawConclusion === "failure" ||
+            rawConclusion === "cancelled" ||
+            rawConclusion === "skipped"
+          ? rawConclusion
+          : "unknown";
+
+    jobs[`${match[1]}-${match[2]}`] = {
+      url: job.html_url,
+      conclusion,
+    };
   }
 
   return NextResponse.json(
-    { runUrl: latestRun.html_url, jobUrls },
+    {
+      runUrl: latestRun.html_url,
+      runConclusion: (latestRun.conclusion ?? latestRun.status) as string,
+      runCreatedAt: latestRun.created_at as string,
+      jobs,
+      lastSuccess:
+        lastSuccessRun && lastSuccessRun.id !== latestRun.id
+          ? {
+              url: lastSuccessRun.html_url as string,
+              createdAt: lastSuccessRun.created_at as string,
+            }
+          : null,
+    },
     {
       headers: {
         "Cache-Control": "public, max-age=300",

--- a/src/components/AutomationFun/AutomationFunSection.tsx
+++ b/src/components/AutomationFun/AutomationFunSection.tsx
@@ -175,6 +175,21 @@ Note: the script pins selenium-webdriver to 4.33.0 via a gem() directive — new
   },
 };
 
+function formatRelative(iso: string): string {
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return "earlier";
+  const diffMs = Date.now() - then;
+  const mins = Math.round(diffMs / 60000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.round(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.round(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  const months = Math.round(days / 30);
+  return `${months}mo ago`;
+}
+
 const availableLangs: Record<string, string[]> = {
   playwright: ["python", "java", "javascript", "ruby"],
   selenium: ["python", "java", "javascript", "ruby"],
@@ -191,8 +206,12 @@ export function AutomationFunSection() {
   const discoTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [copiedCmd, setCopiedCmd] = useState<number | null>(null);
   const hasScrolledRef = useRef(false);
-  const [ciJobUrls, setCiJobUrls] = useState<Record<string, string>>({});
+  type JobConclusion = "success" | "failure" | "cancelled" | "skipped" | "in_progress" | "unknown";
+  type CiJob = { url: string; conclusion: JobConclusion };
+  const [ciJobs, setCiJobs] = useState<Record<string, CiJob>>({});
   const [ciRunUrl, setCiRunUrl] = useState<string | null>(null);
+  const [ciRunConclusion, setCiRunConclusion] = useState<string | null>(null);
+  const [ciLastSuccess, setCiLastSuccess] = useState<{ url: string; createdAt: string } | null>(null);
   const [ciError, setCiError] = useState(false);
   const [ciSort, setCiSort] = useState<{ col: "lang" | "tool" | "status"; dir: 1 | -1 } | null>(null);
   const [ciHoveredRow, setCiHoveredRow] = useState<string | null>(null);
@@ -209,7 +228,7 @@ export function AutomationFunSection() {
     }
   }, []);
 
-  // Fetch CI matrix job URLs
+  // Fetch CI matrix job statuses
   useEffect(() => {
     fetch("/api/ci-matrix")
       .then((r) => {
@@ -217,8 +236,10 @@ export function AutomationFunSection() {
         return r.json();
       })
       .then((data) => {
-        if (data.jobUrls) setCiJobUrls(data.jobUrls);
+        if (data.jobs) setCiJobs(data.jobs);
         if (data.runUrl) setCiRunUrl(data.runUrl);
+        if (data.runConclusion) setCiRunConclusion(data.runConclusion);
+        if (data.lastSuccess) setCiLastSuccess(data.lastSuccess);
         if (data.error) setCiError(true);
       })
       .catch(() => setCiError(true));
@@ -560,11 +581,13 @@ const handleCmdCopy = (text: string, index: number) => {
             const val = (row: string[]) => {
               if (ciSort.col === "lang") return row[0]!;
               if (ciSort.col === "tool") return row[1]!;
-              return "success";
+              return ciJobs[`${row[0]}-${row[1]}`]?.conclusion ?? "unknown";
             };
             return val(a).localeCompare(val(b)) * ciSort.dir;
           }).map(([lang, tool]) => {
-            const jobUrl = ciJobUrls[`${lang}-${tool}`];
+            const job = ciJobs[`${lang}-${tool}`];
+            const jobUrl = job?.url;
+            const conclusion = job?.conclusion;
             const rowKey = `${lang}-${tool}`;
             const isHovered = ciHoveredRow === rowKey;
             const Cell = jobUrl ? "a" : "div";
@@ -574,6 +597,20 @@ const handleCmdCopy = (text: string, index: number) => {
               onMouseLeave: () => setCiHoveredRow(null),
               className: `${jobUrl ? styles["ciGridCellLink"] : styles["ciGridCell"]} ${isHovered ? styles["ciGridRowHovered"] : ""}`,
             };
+            const statusGlyph =
+              conclusion === "success" ? "●" :
+              conclusion === "failure" ? "✕" :
+              conclusion === "cancelled" ? "⊘" :
+              conclusion === "skipped" ? "–" :
+              conclusion === "in_progress" ? "◐" :
+              "●";
+            const statusLabel = conclusion ?? "success";
+            const statusClass =
+              conclusion === "failure" ? styles["ciStatusFail"] :
+              conclusion === "cancelled" ? styles["ciStatusCancelled"] :
+              conclusion === "skipped" ? styles["ciStatusSkipped"] :
+              conclusion === "in_progress" ? styles["ciStatusProgress"] :
+              styles["ciCheck"];
             return (
               <React.Fragment key={rowKey}>
                 <Cell {...cellProps}><img src={`/icons/${lang}_logo.png`} alt="" className={styles["ciToolIcon"]} />{lang}</Cell>
@@ -581,7 +618,7 @@ const handleCmdCopy = (text: string, index: number) => {
                 <Cell {...cellProps} className={`${jobUrl ? styles["ciGridCellLink"] : styles["ciGridCell"]} ${styles["ciGridCellStatus"]} ${isHovered ? styles["ciGridRowHovered"] : ""}`}>
                   {ciError
                     ? <span className={styles["ciErrorStatus"]}>⚠ github api error — reload</span>
-                    : <><span className={styles["ciCheck"]}>●</span> success</>
+                    : <><span className={statusClass}>{statusGlyph}</span> {statusLabel}</>
                   }
                 </Cell>
               </React.Fragment>
@@ -591,11 +628,16 @@ const handleCmdCopy = (text: string, index: number) => {
         <div className={styles["ciLinks"]}>
           {ciRunUrl ? (
             <a href={ciRunUrl} target="_blank" rel="noopener noreferrer">
-              latest run →
+              latest run{ciRunConclusion && ciRunConclusion !== "success" ? ` (${ciRunConclusion})` : ""} →
             </a>
           ) : (
             <a href="https://github.com/snackattas/zattas.me/actions/workflows/automation-detection-production.yml" target="_blank" rel="noopener noreferrer">
               workflow →
+            </a>
+          )}
+          {ciLastSuccess && (
+            <a href={ciLastSuccess.url} target="_blank" rel="noopener noreferrer">
+              last green: {formatRelative(ciLastSuccess.createdAt)} →
             </a>
           )}
           <a

--- a/src/components/AutomationFun/automation.module.css
+++ b/src/components/AutomationFun/automation.module.css
@@ -570,6 +570,34 @@
   color: var(--muted);
 }
 
+.ciStatusFail {
+  font-size: 0.7rem;
+  line-height: 1;
+  flex-shrink: 0;
+  color: #d9534f;
+}
+
+.ciStatusCancelled,
+.ciStatusSkipped {
+  font-size: 0.7rem;
+  line-height: 1;
+  flex-shrink: 0;
+  color: var(--muted);
+}
+
+.ciStatusProgress {
+  font-size: 0.7rem;
+  line-height: 1;
+  flex-shrink: 0;
+  color: #e0a14a;
+  animation: ciProgressPulse 1.4s ease-in-out infinite;
+}
+
+@keyframes ciProgressPulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
 .ciLinks {
   display: flex;
   gap: 20px;


### PR DESCRIPTION
## Summary
The Automation Fun section on the homepage was always showing every CI matrix cell as `success`, even when the most recent main run had actually failed. The cause: `src/app/api/ci-matrix/route.ts` was hardcoding `?status=success` when fetching workflow runs, so it walked past any non-green run and surfaced job links from an older successful one.

This PR fixes both halves of the user-visible bug:

**(b) Show the actual latest run state**
- API now fetches the latest main run unfiltered and returns each job's real `conclusion` (`success` / `failure` / `cancelled` / `skipped` / `in_progress`)
- UI renders per-row status with appropriate glyph + color (red ✕ for failure, amber pulsing ◐ for in-progress, muted ⊘/– for cancelled/skipped)
- Sort-by-status now sorts by actual conclusion instead of a constant
- "latest run →" link surfaces the conclusion inline when not green (e.g. "latest run (failure) →")

**(c) Surface stale-green context**
- API additionally fetches the most recent successful run on main and returns it as `lastSuccess` when distinct from the latest run
- UI adds a "last green: Nd ago →" link to the row of footer links whenever this is present

## Context for reviewers
- The triggering example: run 26234625938 failed due to a transient DNS error inside the GHA runner (`Could not resolve archive.ubuntu.com` during `apt-get update`). Code is fine; the failure just exposed the long-standing reporting bug.
- The old behavior could be defended as "always show working job links," so this PR keeps stale-green context as a separate signal rather than discarding it.

## Test plan
- [ ] Hit `/api/ci-matrix` locally and confirm response shape: `{ runUrl, runConclusion, runCreatedAt, jobs: { "<lang>-<tool>": { url, conclusion } }, lastSuccess: { url, createdAt } | null }`
- [ ] Homepage Automation Fun section shows real per-row statuses (failure rows are red, in-progress pulse amber, etc.)
- [ ] When the most recent run on main is failing, "latest run (failure) →" and "last green: Nd ago →" both appear
- [ ] When the most recent run is green, only "latest run →" appears (no last-green duplicate)
- [ ] Sort by Status column groups failures together